### PR TITLE
Added the type annotation to  val streamId in CatchUpSubscriptionActor.

### DIFF
--- a/src/main/scala/eventstore/CatchUpSubscriptionActor.scala
+++ b/src/main/scala/eventstore/CatchUpSubscriptionActor.scala
@@ -24,7 +24,7 @@ class CatchUpSubscriptionActor(
     val resolveLinkTos: Boolean,
     readBatchSize: Int) extends AbstractSubscriptionActor {
 
-  val streamId = EventStream.All
+  val streamId: EventStream = EventStream.All
 
   def receive = read(
     lastPosition = fromPositionExclusive,


### PR DESCRIPTION
This enables CatchUpSubscriptionActor to be overriden and specialized
in a single stream, rather than the default EventStream.All.
