### PR TITLE
Make event type more explicit in examples

### DIFF
--- a/src/main/java/eventstore/j/examples/EventDataBuilderExample.java
+++ b/src/main/java/eventstore/j/examples/EventDataBuilderExample.java
@@ -7,21 +7,21 @@ import java.util.UUID;
 
 public class EventDataBuilderExample {
 
-    final EventData empty = new EventDataBuilder("empty").build();
+    final EventData empty = new EventDataBuilder("eventType").build();
 
-    final EventData binary = new EventDataBuilder("binary")
+    final EventData binary = new EventDataBuilder("eventType")
             .eventId(UUID.randomUUID())
             .data(new byte[]{1, 2, 3, 4})
             .metadata(new byte[]{5, 6, 7, 8})
             .build();
 
-    final EventData string = new EventDataBuilder("string")
+    final EventData string = new EventDataBuilder("eventType")
             .eventId(UUID.randomUUID())
             .data("data")
             .metadata("metadata")
             .build();
 
-    final EventData json = new EventDataBuilder("json")
+    final EventData json = new EventDataBuilder("eventType")
             .eventId(UUID.randomUUID())
             .jsonData("{\"data\":\"data\"}")
             .jsonMetadata("{\"metadata\":\"metadata\"}")


### PR DESCRIPTION
There was some confusion from a customer about where event type was specified - this should clear it up a bit.