### PR TITLE
Akka 2.4.1 & Akka Streams 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   </tr>
   <tr>
     <td><a href="http://akka.io">Akka</a> </td>
-    <td>2.4.0</td>
+    <td>2.4.1</td>
   </tr>
 </table>
 
@@ -20,7 +20,7 @@ We have two APIs available:
 
 We are using [`scala.concurrent.Future`](http://docs.scala-lang.org/overviews/core/futures.html) for asynchronous calls, however it is not friendly enough for Java users.
 In order to make Java devs happy and not reinvent a wheel, we propose to use tools invented by Akka team.
-[Check it out](http://doc.akka.io/docs/akka/2.4.0/java/futures.html)
+[Check it out](http://doc.akka.io/docs/akka/2.4.1/java/futures.html)
 
 ```java
 final EsConnection connection = EsConnectionFactory.create(system);

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -46,7 +46,7 @@ object Build extends Build {
     val tck     = apply("akka-stream-tck-experimental") % "test"
     val testkit = apply("akka-stream-testkit-experimental") % "test"
 
-    private def apply(x: String) = "com.typesafe.akka" %% x % "2.0"
+    private def apply(x: String) = "com.typesafe.akka" %% x % "2.0.1"
   }
 
   object Specs2 {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -37,7 +37,7 @@ object Build extends Build {
     val actor   = apply("akka-actor")
     val testkit = apply("akka-testkit") % "test"
 
-    private def apply(x: String) = "com.typesafe.akka" %% x % "2.4.0"
+    private def apply(x: String) = "com.typesafe.akka" %% x % "2.4.1"
   }
 
   object AkkaStream {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -46,7 +46,7 @@ object Build extends Build {
     val tck     = apply("akka-stream-tck-experimental") % "test"
     val testkit = apply("akka-stream-testkit-experimental") % "test"
 
-    private def apply(x: String) = "com.typesafe.akka" %% x % "1.0"
+    private def apply(x: String) = "com.typesafe.akka" %% x % "2.0"
   }
 
   object Specs2 {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/src/main/scala/eventstore/examples/ListAllStreamsExample.scala
+++ b/src/main/scala/eventstore/examples/ListAllStreamsExample.scala
@@ -11,7 +11,7 @@ object ListAllStreamsExample extends App {
   implicit val materializer = ActorMaterializer()
   val connection = EventStoreExtension(system).connection
   val publisher = connection.streamPublisher(EventStream.System.`$streams`, infinite = false, resolveLinkTos = true)
-  Source(publisher)
+  Source.fromPublisher(publisher)
     .runForeach { x => println(x.streamId.streamId) }
     .onComplete { _ => system.terminate() }
 }

--- a/src/main/scala/eventstore/examples/MessagesPerSecondReactiveStreams.scala
+++ b/src/main/scala/eventstore/examples/MessagesPerSecondReactiveStreams.scala
@@ -13,7 +13,7 @@ object MessagesPerSecondReactiveStreams extends App {
   val connection = EventStoreExtension(system).connection
   val publisher = connection.allStreamsPublisher()
 
-  Source(publisher)
+  Source.fromPublisher(publisher)
     .groupedWithin(Int.MaxValue, 1.second)
     .runForeach { xs => println(f"${xs.size.toDouble / 1000}%2.1fk m/s") }
 }

--- a/src/test/scala/eventstore/StreamPublisherITest.scala
+++ b/src/test/scala/eventstore/StreamPublisherITest.scala
@@ -80,7 +80,7 @@ class StreamPublisherITest extends TestConnection {
     val connection = new EsConnection(actor, system)
 
     def source(eventNumber: Option[EventNumber] = None, infinite: Boolean = true) = {
-      Source(connection.streamPublisher(streamId, eventNumber, infinite = infinite))
+      Source.fromPublisher(connection.streamPublisher(streamId, eventNumber, infinite = infinite))
     }
   }
 }

--- a/src/test/scala/eventstore/j/EsConnectionITest.scala
+++ b/src/test/scala/eventstore/j/EsConnectionITest.scala
@@ -142,7 +142,7 @@ class EsConnectionITest extends eventstore.util.ActorSpec {
       val streamId = s"java-publish-$randomUuid"
       val publisher = connection.streamPublisher(streamId, null, false, null, false)
       await_(connection.writeEvents(streamId, null, events, null))
-      Source(publisher)
+      Source.fromPublisher(publisher)
         .map(_.data)
         .runWith(TestSink.probe[EventData])
         .request(1)
@@ -152,7 +152,7 @@ class EsConnectionITest extends eventstore.util.ActorSpec {
 
     "publish all streams" in new TestScope {
       val publisher = connection.allStreamsPublisher(Position.First, false, null, true)
-      val probe = Source(publisher)
+      val probe = Source.fromPublisher(publisher)
         .runWith(TestSink.probe[IndexedEvent])
         .request(10)
 


### PR DESCRIPTION
Some integration tests fail on Event Store 3.3.0.0:

```
[error] Error: Total 190, Failed 12, Errors 1, Passed 177, Pending 4
[error] Failed tests:
[error] 	eventstore.ReadAllEventsBackwardITest
[error] 	eventstore.ReadAllEventsForwardITest
[error] 	eventstore.SubscribeToAllITest
[error] 	eventstore.SubscribeToAllCatchingUpITest
[error] Error during tests:
[error] 	eventstore.j.EsConnectionITest
[error] (it:test) sbt.TestsFailedException: Tests unsuccessful
```