### PR TITLE
Add operation timeout when reconnecting

### DIFF
--- a/src/main/scala/eventstore/tcp/ConnectionActor.scala
+++ b/src/main/scala/eventstore/tcp/ConnectionActor.scala
@@ -281,6 +281,7 @@ private[eventstore] class ConnectionActor(settings: Settings) extends Actor with
       val result = os.flatMap { operation =>
         operation.connected match {
           case OnConnected.Retry(operation, packOut) =>
+            system.scheduler.scheduleOnce(settings.operationTimeout, self, TimedOut(packOut.correlationId, operation.version))
             connection(packOut)
             List(operation)
           case OnConnected.Stop(in) =>


### PR DESCRIPTION
When reconnecting, the connect itself may succeed, but retrying the subscribeTo operation
may timeout. This happens for example when EventStore is in the process of restarting. If
we wouldn't make the scheduleOnce call and subscribeTo indeed times out, we will never be
informed about it and consequently can never recover from it.