### PR TITLE
85 - Exception instead of actor stop on cluster failure?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: scala
 
+env:
+  - AKKA_TEST_TIMEFACTOR=2.0
+
 scala:
   - 2.12.2
   - 2.11.11

--- a/src/main/scala/eventstore/tcp/ConnectionActor.scala
+++ b/src/main/scala/eventstore/tcp/ConnectionActor.scala
@@ -142,7 +142,7 @@ private[eventstore] class ConnectionActor(settings: Settings) extends Actor with
             case PackIn(Failure(NotHandled(NotMaster(x))), _) => reconnect(x.tcpAddress, "NotMaster failure received")
             case ClusterFailure(x) =>
               log.error("Cluster failed with error: {}", x)
-              context stop self
+              throw new RetriesLimitReachedException(x.toString)
           }
       }
 

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,0 +1,2 @@
+akka.test.timefactor = 1.0
+akka.test.timefactor = ${?AKKA_TEST_TIMEFACTOR}


### PR DESCRIPTION
Throwing exceptions after maxRetries connection attempts.

This should fix #85.