### PR TITLE
all: 64-bit event numbers (eventstore >=4.0.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: scala
 
 scala:
-  - 2.12.2
+  - 2.12.3
   - 2.11.11
+
+env:
+  global:
+    - AKKA_TEST_TIMEFACTOR=2.0
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@
 <table border="0">
   <tr>
     <td><a href="http://www.scala-lang.org">Scala</a> </td>
-    <td>2.12.2/2.11.11</td>
+    <td>2.12.3/2.11.11</td>
   </tr>
   <tr>
     <td><a href="http://akka.io">Akka</a> </td>
-    <td>2.5.1</td>
+    <td>2.5.4</td>
   </tr>
+  <tr>
+    <td><a href="https://eventstore.org">Event Store</a></td>
+    <td>v4.0.0 and higher is supported</td>
+  </tr>  
 </table>
 
 
@@ -18,7 +22,7 @@ We have two APIs available:
 
 We are using [`scala.concurrent.Future`](http://docs.scala-lang.org/overviews/core/futures.html) for asynchronous calls, however it is not friendly enough for Java users.
 In order to make Java devs happy and not reinvent a wheel, we propose to use tools invented by Akka team.
-[Check it out](http://doc.akka.io/docs/akka/2.5.1/java/futures.html)
+[Check it out](http://doc.akka.io/docs/akka/2.5.4/java/futures.html)
 
 ```java
 final EsConnection connection = EsConnectionFactory.create(system);
@@ -50,7 +54,7 @@ connection ! ReadEvent(EventStream.Id("my-stream"), EventNumber.First)
 
 #### Sbt
 ```scala
-libraryDependencies += "com.geteventstore" %% "eventstore-client" % "4.1.1"
+libraryDependencies += "com.geteventstore" %% "eventstore-client" % "4.2.0"
 ```
 
 #### Maven
@@ -58,7 +62,7 @@ libraryDependencies += "com.geteventstore" %% "eventstore-client" % "4.1.1"
 <dependency>
     <groupId>com.geteventstore</groupId>
     <artifactId>eventstore-client_${scala.version}</artifactId>
-    <version>4.1.1</version>
+    <version>4.2.0</version>
 </dependency>
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,9 @@ name := "eventstore-client"
 
 organization := "com.geteventstore"
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.3"
 
-crossScalaVersions := Seq("2.12.2", "2.11.11")
+crossScalaVersions := Seq("2.12.3", "2.11.11")
 
 releaseCrossBuild := true
 
@@ -39,10 +39,10 @@ scalacOptions ++= Seq(
 
 scalacOptions in(Compile, doc) ++= Seq("-groups", "-implicits", "-no-link-warnings")
 
-val AkkaVersion = "2.5.1"
-val AkkaHttpVersion = "10.0.6"
-val ReactiveStreamsVersion = "1.0.0"
-val Specs2Version = "3.8.9"
+val AkkaVersion = "2.5.4"
+val AkkaHttpVersion = "10.0.10"
+val ReactiveStreamsVersion = "1.0.1"
+val Specs2Version = "3.8.6" // Because of concurrency issues with specs2 3.8.7+
 
 libraryDependencies ++= Seq(
   "org.reactivestreams" % "reactive-streams" % ReactiveStreamsVersion,
@@ -57,7 +57,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
   "org.apache.directory.studio" % "org.apache.commons.codec" % "1.8",
   "joda-time" % "joda-time" % "2.9.9",
-  "org.joda" % "joda-convert" % "1.8.1",
+  "org.joda" % "joda-convert" % "1.8.3",
   "org.mockito" % "mockito-all" % "1.10.19" % Test,
   "org.specs2" %% "specs2-core" % Specs2Version % Test,
   "org.specs2" %% "specs2-mock" % Specs2Version % Test)

--- a/src/main/java/eventstore/j/EsConnection.java
+++ b/src/main/java/eventstore/j/EsConnection.java
@@ -377,7 +377,7 @@ public interface EsConnection {
   Closeable subscribeToStreamFrom(
       String stream,
       SubscriptionObserver<Event> observer,
-      Integer fromEventNumberExclusive,
+      Long fromEventNumberExclusive,
       boolean resolveLinkTos,
       UserCredentials credentials);
 

--- a/src/main/protobuf/EventStoreMessages.proto
+++ b/src/main/protobuf/EventStoreMessages.proto
@@ -23,7 +23,7 @@ message NewEvent {
 
 message EventRecord {
   required string event_stream_id = 1;
-  required int32 event_number = 2;
+  required int64 event_number = 2;
   required bytes event_id = 3;
   required string event_type = 4;
   required int32 data_content_type = 5;
@@ -48,7 +48,7 @@ message ResolvedEvent {
 
 message WriteEvents {
   required string event_stream_id = 1;
-  required int32 expected_version = 2;
+  required int64 expected_version = 2;
   repeated NewEvent events = 3;
   required bool require_master = 4;
 }
@@ -56,15 +56,16 @@ message WriteEvents {
 message WriteEventsCompleted {
   required OperationResult result = 1;
   optional string message = 2;
-  required int32 first_event_number = 3;
-  required int32 last_event_number = 4;
+  required int64 first_event_number = 3;
+  required int64 last_event_number = 4;
   optional int64 prepare_position = 5;
   optional int64 commit_position = 6;
+  // optional int64 current_version  = 7; -- Add later, https://github.com/EventStore/EventStore/commit/95832cf1320ae74d3a79c3950547b54e28b8f3b6#diff-fa5234643c26663dd9d0e5ff7c836e16
 }
 
 message DeleteStream {
   required string event_stream_id = 1;
-  required int32 expected_version = 2;
+  required int64 expected_version = 2;
   required bool require_master = 3;
   optional bool hard_delete = 4;
 }
@@ -78,7 +79,7 @@ message DeleteStreamCompleted {
 
 message TransactionStart {
   required string event_stream_id = 1;
-  required int32 expected_version = 2;
+  required int64 expected_version = 2;
   required bool require_master = 3;
 }
 
@@ -109,15 +110,15 @@ message TransactionCommitCompleted {
   required int64 transaction_id = 1;
   required OperationResult result = 2;
   optional string message = 3;
-  required int32 first_event_number = 4;
-  required int32 last_event_number = 5;
+  required int64 first_event_number = 4;
+  required int64 last_event_number = 5;
   optional int64 prepare_position = 6;
   optional int64 commit_position = 7;
 }
 
 message ReadEvent {
   required string event_stream_id = 1;
-  required int32 event_number = 2;
+  required int64 event_number = 2;
   required bool resolve_link_tos = 3;
   required bool require_master = 4;
 }
@@ -141,7 +142,7 @@ message ReadEventCompleted {
 
 message ReadStreamEvents {
   required string event_stream_id = 1;
-  required int32 from_event_number = 2;
+  required int64 from_event_number = 2;
   required int32 max_count = 3;
   required bool resolve_link_tos = 4;
   required bool require_master = 5;
@@ -160,8 +161,8 @@ message ReadStreamEventsCompleted {
 
   repeated ResolvedIndexedEvent events = 1;
   required ReadStreamResult result = 2;
-  required int32 next_event_number = 3;
-  required int32 last_event_number = 4;
+  required int64 next_event_number = 3;
+  required int64 last_event_number = 4;
   required bool is_end_of_stream = 5;
   required int64 last_commit_position = 6;
 
@@ -199,7 +200,7 @@ message CreatePersistentSubscription {
   required string subscription_group_name = 1;
   required string event_stream_id = 2;
   required bool resolve_link_tos = 3;
-  required int32 start_from = 4;
+  required int64 start_from = 4;
   required int32 message_timeout_milliseconds = 5;
   required bool record_statistics = 6;
   required int32 live_buffer_size = 7;
@@ -223,7 +224,7 @@ message UpdatePersistentSubscription {
   required string subscription_group_name = 1;
   required string event_stream_id = 2;
   required bool resolve_link_tos = 3;
-  required int32 start_from = 4;
+  required int64 start_from = 4;
   required int32 message_timeout_milliseconds = 5;
   required bool record_statistics = 6;
   required int32 live_buffer_size = 7;
@@ -301,7 +302,7 @@ message PersistentSubscriptionNakEvents {
 message PersistentSubscriptionConfirmation {
   required int64 last_commit_position = 1;
   required string subscription_id = 2;
-  optional int32 last_event_number = 3;
+  optional int64 last_event_number = 3;
 }
 
 message PersistentSubscriptionStreamEventAppeared {
@@ -315,7 +316,7 @@ message SubscribeToStream {
 
 message SubscriptionConfirmation {
   required int64 last_commit_position = 1;
-  optional int32 last_event_number = 2;
+  optional int64 last_event_number = 2;
 }
 
 message StreamEventAppeared {
@@ -374,4 +375,13 @@ message ScavengeDatabaseCompleted {
   optional string error = 2;
   required int32 total_time_ms = 3;
   required int64 total_space_saved = 4;
+}
+
+
+message IdentifyClient {
+  required int32  version         = 1; // 1 to identify as 64-bit, 0 as legacy 32-bit
+  optional string connection_name = 2;
+}
+
+message ClientIdentified {
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -14,6 +14,9 @@ eventstore {
   # The desired connection timeout
   connection-timeout = 1s
 
+  # Friendly name for identifying client on server
+  connection-name = "jvm-client"
+
   # Maximum number of reconnections before backing, -1 to reconnect forever
   max-reconnections = 100
 

--- a/src/main/scala/eventstore/Event.scala
+++ b/src/main/scala/eventstore/Event.scala
@@ -27,7 +27,7 @@ sealed trait Event extends Ordered[Event] {
 object Event {
   object StreamDeleted {
     def unapply(x: Event): Boolean = cond(x.record) {
-      case EventRecord(_, EventNumber.Exact(Int.MaxValue), EventData.StreamDeleted(), _) => true
+      case EventRecord(_, EventNumber.Exact(Long.MaxValue), EventData.StreamDeleted(), _) => true
     }
   }
 

--- a/src/main/scala/eventstore/EventNumber.scala
+++ b/src/main/scala/eventstore/EventNumber.scala
@@ -11,7 +11,7 @@ object EventNumber {
     case ReadDirection.Backward => Last
   }
 
-  def apply(eventNumber: Int): EventNumber = if (eventNumber < 0) Last else Exact(eventNumber)
+  def apply(eventNumber: Long): EventNumber = if (eventNumber < 0) Last else Exact(eventNumber)
 
   @SerialVersionUID(1L) case object Last extends EventNumber {
     def compare(that: EventNumber) = that match {
@@ -22,7 +22,7 @@ object EventNumber {
     override def toString = "EventNumber.Last"
   }
 
-  @SerialVersionUID(1L) case class Exact(value: Int) extends EventNumber {
+  @SerialVersionUID(1L) case class Exact(value: Long) extends EventNumber {
     require(value >= 0, s"event number must be >= 0, but is $value")
 
     def compare(that: EventNumber) = that match {
@@ -40,7 +40,7 @@ object EventNumber {
 
     def apply(expectedVersion: ExpectedVersion.Exact): Exact = Exact(expectedVersion.value)
 
-    def opt(proto: Int): Option[EventNumber.Exact] = if (proto >= 0) Some(Exact(proto)) else None
+    def opt(proto: Long): Option[EventNumber.Exact] = if (proto >= 0) Some(Exact(proto)) else None
   }
 
   @SerialVersionUID(1L) case class Range(start: Exact, end: Exact) {
@@ -52,11 +52,11 @@ object EventNumber {
   object Range {
     def apply(number: Exact): Range = Range(number, number)
 
-    def apply(start: Int, end: Int): Range = Range(Exact(start), Exact(end))
+    def apply(start: Long, end: Long): Range = Range(Exact(start), Exact(end))
 
-    def apply(start: Int): Range = Range(Exact(start))
+    def apply(start: Long): Range = Range(Exact(start))
 
-    def opt(first: Int, last: Int): Option[Range] = {
+    def opt(first: Long, last: Long): Option[Range] = {
       if (first > last) None
       else for {
         f <- Exact.opt(first)

--- a/src/main/scala/eventstore/ExpectedVersion.scala
+++ b/src/main/scala/eventstore/ExpectedVersion.scala
@@ -5,7 +5,7 @@ sealed trait ExpectedVersion
 object ExpectedVersion {
   val First: Exact = Exact(0)
 
-  def apply(expectedVersion: Int): ExpectedVersion = expectedVersion match {
+  def apply(expectedVersion: Long): ExpectedVersion = expectedVersion match {
     case -1 => ExpectedVersion.NoStream
     case -2 => ExpectedVersion.Any
     case _  => ExpectedVersion.Exact(expectedVersion)
@@ -24,7 +24,7 @@ object ExpectedVersion {
   }
 
   // States that the last event written to the stream should have a sequence number matching your expected value.
-  @SerialVersionUID(1L) case class Exact(value: Int) extends Existing {
+  @SerialVersionUID(1L) case class Exact(value: Long) extends Existing {
     require(value >= 0, s"expected version must be >= 0, but is $value")
 
     override def toString = s"Expected.Version($value)"

--- a/src/main/scala/eventstore/Message.scala
+++ b/src/main/scala/eventstore/Message.scala
@@ -29,6 +29,15 @@ sealed trait InOut extends In with Out
 @SerialVersionUID(1L) case object Ping extends InOut
 @SerialVersionUID(1L) case object Pong extends InOut
 
+@SerialVersionUID(1L) case class IdentifyClient(
+    version:        Int,
+    connectionName: Option[String]
+) extends Out {
+  require(version >= 0, s"version must be >= 0, but is $version")
+}
+
+@SerialVersionUID(1L) case object ClientIdentified extends In
+
 @SerialVersionUID(1L) case class WriteEvents(
   streamId:        EventStream.Id,
   events:          List[EventData],

--- a/src/main/scala/eventstore/PersistentSubscriptionSettings.scala
+++ b/src/main/scala/eventstore/PersistentSubscriptionSettings.scala
@@ -48,7 +48,7 @@ object PersistentSubscriptionSettings {
 
       def startFrom = {
         val path = "start-from"
-        try EventNumber(conf getInt path) catch {
+        try EventNumber(conf getLong path) catch {
           case e: ConfigException.WrongType => conf getString path match {
             case "last" | "current" => EventNumber.Last
             case "first"            => EventNumber.First

--- a/src/main/scala/eventstore/Settings.scala
+++ b/src/main/scala/eventstore/Settings.scala
@@ -28,6 +28,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
  * @param http Url to access eventstore though the Http API
  * @param serializationParallelism The number of serialization/deserialization functions to be run in parallel
  * @param serializationOrdered Serialization done asynchronously and these futures may complete in any order, but results will be used with preserved order if set to true
+ * @param connectionName Client identifier used to show a friendly name of client in Event Store.
  */
 @SerialVersionUID(1L)
 case class Settings(
@@ -49,7 +50,8 @@ case class Settings(
     cluster:                  Option[ClusterSettings] = None,
     http:                     HttpSettings            = HttpSettings(),
     serializationParallelism: Int                     = 8,
-    serializationOrdered:     Boolean                 = true
+    serializationOrdered:     Boolean                 = true,
+    connectionName:           Option[String]          = Some("jvm-client")
 ) {
   require(reconnectionDelayMin > Duration.Zero, "reconnectionDelayMin must be > 0")
   require(reconnectionDelayMax > Duration.Zero, "reconnectionDelayMax must be > 0")
@@ -93,7 +95,8 @@ object Settings {
         cluster = cluster,
         http = HttpSettings(conf),
         serializationParallelism = conf getInt "serialization-parallelism",
-        serializationOrdered = conf getBoolean "serialization-ordered"
+        serializationOrdered = conf getBoolean "serialization-ordered",
+        connectionName = Option(conf getString "connection-name").filter(_.nonEmpty)
       )
     }
     apply(conf getConfig "eventstore")

--- a/src/main/scala/eventstore/j/Builder.scala
+++ b/src/main/scala/eventstore/j/Builder.scala
@@ -15,7 +15,7 @@ object Builder {
 
     def expectNoStream: T = expectVersion(ExpectedVersion.NoStream)
     def expectAnyVersion: T = expectVersion(ExpectedVersion.Any)
-    def expectVersion(x: Int): T = expectVersion(ExpectedVersion.Exact(x))
+    def expectVersion(x: Long): T = expectVersion(ExpectedVersion.Exact(x))
     def expectVersion(x: ExpectedVersion): T = set {
       _expectVersion = x
     }

--- a/src/main/scala/eventstore/j/DeleteStreamBuilder.scala
+++ b/src/main/scala/eventstore/j/DeleteStreamBuilder.scala
@@ -16,7 +16,7 @@ class DeleteStreamBuilder(streamId: String) extends Builder[DeleteStream]
 
   def expectAnyVersion: DeleteStreamBuilder = expectVersion(ExpectedVersion.Any)
 
-  def expectVersion(x: Int): DeleteStreamBuilder = expectVersion(ExpectedVersion.Exact(x))
+  def expectVersion(x: Long): DeleteStreamBuilder = expectVersion(ExpectedVersion.Exact(x))
 
   def expectVersion(x: ExpectedVersion.Existing): DeleteStreamBuilder = set {
     _expectVersion = x

--- a/src/main/scala/eventstore/j/EsConnectionImpl.scala
+++ b/src/main/scala/eventstore/j/EsConnectionImpl.scala
@@ -254,7 +254,7 @@ class EsConnectionImpl(
   def subscribeToStreamFrom(
     stream:                   String,
     observer:                 SubscriptionObserver[Event],
-    fromEventNumberExclusive: java.lang.Integer,
+    fromEventNumberExclusive: java.lang.Long,
     resolveLinkTos:           Boolean,
     credentials:              UserCredentials
   ) = {

--- a/src/main/scala/eventstore/j/PersistentSubscriptionSettingsBuilder.scala
+++ b/src/main/scala/eventstore/j/PersistentSubscriptionSettingsBuilder.scala
@@ -35,7 +35,7 @@ class PersistentSubscriptionSettingsBuilder
     _startFrom = x
   }
 
-  def startFrom(x: Int): PersistentSubscriptionSettingsBuilder = {
+  def startFrom(x: Long): PersistentSubscriptionSettingsBuilder = {
     startFrom(EventNumber(x))
   }
 

--- a/src/main/scala/eventstore/j/ReadEventBuilder.scala
+++ b/src/main/scala/eventstore/j/ReadEventBuilder.scala
@@ -14,7 +14,7 @@ class ReadEventBuilder(streamId: String) extends Builder[ReadEvent]
     _eventNumber = x
   }
 
-  def number(x: Int): ReadEventBuilder = number(EventNumber(x))
+  def number(x: Long): ReadEventBuilder = number(EventNumber(x))
 
   def first: ReadEventBuilder = number(EventNumber.First)
 

--- a/src/main/scala/eventstore/j/ReadStreamEventsBuilder.scala
+++ b/src/main/scala/eventstore/j/ReadStreamEventsBuilder.scala
@@ -16,7 +16,7 @@ class ReadStreamEventsBuilder(streamId: String) extends Builder[ReadStreamEvents
     _fromNumber = x
   }
 
-  def fromNumber(x: Int): ReadStreamEventsBuilder = fromNumber(if (x < 0) EventNumber.Last else EventNumber(x))
+  def fromNumber(x: Long): ReadStreamEventsBuilder = fromNumber(if (x < 0) EventNumber.Last else EventNumber(x))
 
   def fromFirst: ReadStreamEventsBuilder = fromNumber(EventNumber.First)
 

--- a/src/main/scala/eventstore/j/SettingsBuilder.scala
+++ b/src/main/scala/eventstore/j/SettingsBuilder.scala
@@ -28,10 +28,13 @@ class SettingsBuilder extends Builder[Settings]
   protected var _http = Default.http
   protected var _serializationParallelism = Default.serializationParallelism
   protected var _serializationOrdered = Default.serializationOrdered
+  protected var _connectionName = Default.connectionName
 
   def address(x: InetSocketAddress): SettingsBuilder = set { _address = x }
 
   def address(host: String): SettingsBuilder = address(host :: Default.address.getPort)
+
+  def connectionName(name: String): SettingsBuilder = set { _connectionName = Option(name) }
 
   def connectionTimeout(x: FiniteDuration): SettingsBuilder = set { _connectionTimeout = x }
 
@@ -139,6 +142,7 @@ class SettingsBuilder extends Builder[Settings]
     cluster = _cluster,
     http = _http,
     serializationParallelism = _serializationParallelism,
-    serializationOrdered = _serializationOrdered
+    serializationOrdered = _serializationOrdered,
+    connectionName = _connectionName
   )
 }

--- a/src/main/scala/eventstore/j/TransactionStartBuilder.scala
+++ b/src/main/scala/eventstore/j/TransactionStartBuilder.scala
@@ -11,7 +11,7 @@ class TransactionStartBuilder(streamId: String) extends Builder[TransactionStart
 
   override def expectNoStream: TransactionStartBuilder = super.expectNoStream
   override def expectAnyVersion: TransactionStartBuilder = super.expectAnyVersion
-  override def expectVersion(x: Int): TransactionStartBuilder = super.expectVersion(x)
+  override def expectVersion(x: Long): TransactionStartBuilder = super.expectVersion(x)
   override def expectVersion(x: ExpectedVersion): TransactionStartBuilder = super.expectVersion(x)
 
   override def performOnAnyNode: TransactionStartBuilder = super.performOnAnyNode

--- a/src/main/scala/eventstore/j/WriteEventsBuilder.scala
+++ b/src/main/scala/eventstore/j/WriteEventsBuilder.scala
@@ -18,7 +18,7 @@ class WriteEventsBuilder(streamId: String) extends Builder[WriteEvents]
 
   override def expectNoStream: WriteEventsBuilder = super.expectNoStream
   override def expectAnyVersion: WriteEventsBuilder = super.expectAnyVersion
-  override def expectVersion(x: Int): WriteEventsBuilder = super.expectVersion(x)
+  override def expectVersion(x: Long): WriteEventsBuilder = super.expectVersion(x)
   override def expectVersion(x: ExpectedVersion): WriteEventsBuilder = super.expectVersion(x)
 
   override def performOnAnyNode: WriteEventsBuilder = super.performOnAnyNode

--- a/src/main/scala/eventstore/operations/Operation.scala
+++ b/src/main/scala/eventstore/operations/Operation.scala
@@ -42,6 +42,7 @@ private[eventstore] object Operation {
       case Unsubscribe          => Some(simple(UnsubscribeInspection))
       case ScavengeDatabase     => Some(simple(ScavengeDatabaseInspection))
       case Authenticate         => Some(simple(AuthenticateInspection))
+      case _: IdentifyClient    => Some(simple(IdentifyClientInspection))
       case Ping                 => Some(simple(PingInspection))
       case Pong                 => None
       case HeartbeatRequest     => Some(simple(HeartbeatRequestInspection))
@@ -50,8 +51,8 @@ private[eventstore] object Operation {
       case x: Ps.Create         => Some(simple(CreatePersistentSubscriptionInspection(x)))
       case x: Ps.Update         => Some(simple(UpdatePersistentSubscriptionInspection(x)))
       case x: Ps.Delete         => Some(simple(DeletePersistentSubscriptionInspection(x)))
-      case x: Ps.Ack            => None
-      case x: Ps.Nak            => None
+      case _: Ps.Ack            => None
+      case _: Ps.Nak            => None
     }
   }
 }

--- a/src/main/scala/eventstore/operations/SimpleInspection.scala
+++ b/src/main/scala/eventstore/operations/SimpleInspection.scala
@@ -16,3 +16,5 @@ private[eventstore] case object PingInspection extends SimpleInspection(Pong)
 private[eventstore] case object UnsubscribeInspection extends SimpleInspection(Unsubscribed)
 
 private[eventstore] case object HeartbeatRequestInspection extends SimpleInspection(HeartbeatResponse)
+
+private[eventstore] case object IdentifyClientInspection extends SimpleInspection(ClientIdentified)

--- a/src/main/scala/eventstore/tcp/EventStoreFormats.scala
+++ b/src/main/scala/eventstore/tcp/EventStoreFormats.scala
@@ -16,6 +16,7 @@ trait EventStoreFormats extends EventStoreProtoFormats {
   implicit object HeartbeatResponseFormat extends EmptyFormat(HeartbeatResponse)
   implicit object PingFormat extends EmptyFormat(Ping)
   implicit object PongFormat extends EmptyFormat(Pong)
+  implicit object ClientIdentifiedFormat extends EmptyFormat(ClientIdentified)
   implicit object UnsubscribeFromStreamFormat extends EmptyFormat(Unsubscribe)
   implicit object ScavengeDatabaseFormat extends EmptyFormat(ScavengeDatabase)
   implicit object AuthenticateFormat extends EmptyFormat(Authenticate)

--- a/src/main/scala/eventstore/tcp/MarkerByte.scala
+++ b/src/main/scala/eventstore/tcp/MarkerByte.scala
@@ -75,7 +75,9 @@ object MarkerByte {
     0xF0 -> readerFailure(BadRequest),
     0xF1 -> readerFailure[NotHandled],
     0xF3 -> reader[Authenticated.type],
-    0xF4 -> readerFailure(NotAuthenticated)
+    0xF4 -> readerFailure(NotAuthenticated),
+
+    0xF6 -> reader[ClientIdentified.type]
   ).map {
       case (key, value) => key.toByte -> value
     }
@@ -122,16 +124,18 @@ object MarkerByte {
       case Backward => writer(0xB8, x)
     }
 
-    case x: Ps.Connect    => writer(0xC5, x)
-    case x: Ps.Ack        => writer(0xCC, x)
-    case x: Ps.Nak        => writer(0xCD, x)
-    case x: Ps.Create     => writer(0xC8, x)
-    case x: Ps.Delete     => writer(0xCA, x)
-    case x: Ps.Update     => writer(0xCE, x)
+    case x: Ps.Connect     => writer(0xC5, x)
+    case x: Ps.Ack         => writer(0xCC, x)
+    case x: Ps.Nak         => writer(0xCD, x)
+    case x: Ps.Create      => writer(0xC8, x)
+    case x: Ps.Delete      => writer(0xCA, x)
+    case x: Ps.Update      => writer(0xCE, x)
 
-    case x: SubscribeTo   => writer(0xC0, x)
-    case Unsubscribe      => writer(0xC3, Unsubscribe)
-    case ScavengeDatabase => writer(0xD0, ScavengeDatabase)
-    case Authenticate     => writer(0xF2, Authenticate)
+    case x: SubscribeTo    => writer(0xC0, x)
+    case Unsubscribe       => writer(0xC3, Unsubscribe)
+    case ScavengeDatabase  => writer(0xD0, ScavengeDatabase)
+    case Authenticate      => writer(0xF2, Authenticate)
+
+    case x: IdentifyClient => writer(0xF5, x)
   }
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -2,4 +2,7 @@ akka {
   loglevel = "ERROR"
   log-dead-letters = off
   log-dead-letters-during-shutdown = off
+
+  test.timefactor = 1.0
+  test.timefactor = ${?AKKA_TEST_TIMEFACTOR}
 }

--- a/src/test/scala/eventstore/AbstractSubscriptionActorSpec.scala
+++ b/src/test/scala/eventstore/AbstractSubscriptionActorSpec.scala
@@ -27,7 +27,7 @@ abstract class AbstractSubscriptionActorSpec extends util.ActorSpec with Mockito
       connection.expectNoMsg(duration)
     }
 
-    def streamEventAppeared(x: Event) = StreamEventAppeared(IndexedEvent(x, Position.Exact(x.number.value.toLong)))
+    def streamEventAppeared(x: Event) = StreamEventAppeared(IndexedEvent(x, Position.Exact(x.number.value)))
 
     def subscribeTo = SubscribeTo(streamId, resolveLinkTos = resolveLinkTos)
 

--- a/src/test/scala/eventstore/MessageSpec.scala
+++ b/src/test/scala/eventstore/MessageSpec.scala
@@ -49,6 +49,12 @@ class MessageSpec extends Specification with Mockito {
     }
   }
 
+  "IdentifyClient" should {
+    "throw exception if version < 0" in {
+      IdentifyClient(-1, None) must throwAn[IllegalArgumentException]
+    }
+  }
+
   "ReadStreamEventsCompleted" should {
     "throw exception if reading forward and nextEventNumber is EventNumber.Last" in {
       ReadStreamEventsCompleted(Nil, EventNumber.Last, EventNumber.Exact(0), endOfStream = false, 0,

--- a/src/test/scala/eventstore/PersistentSubscriptionActorSpec.scala
+++ b/src/test/scala/eventstore/PersistentSubscriptionActorSpec.scala
@@ -69,7 +69,7 @@ class PersistentSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
 
     def expectAck(): Unit = connection.expectMsgType[Ack]
 
-    def newEvent(number: Int): Event = EventRecord(streamId, EventNumber.Exact(number), mock[EventData])
+    def newEvent(number: Long): Event = EventRecord(streamId, EventNumber.Exact(number), mock[EventData])
 
     def eventAppeared(event: Event) =
       EventAppeared(event)

--- a/src/test/scala/eventstore/PositionSpec.scala
+++ b/src/test/scala/eventstore/PositionSpec.scala
@@ -98,7 +98,7 @@ class PositionSpec extends Specification {
   }
 
   private trait PositionScope extends Scope {
-    val values = List[Long](0L, 1L, Int.MaxValue)
+    val values = List[Long](0L, 1L, Long.MaxValue)
     val positions = Last :: (for {
       commitPosition <- values
       preparePosition <- values if commitPosition >= preparePosition

--- a/src/test/scala/eventstore/ProjectionsClientITest.scala
+++ b/src/test/scala/eventstore/ProjectionsClientITest.scala
@@ -267,7 +267,7 @@ class ProjectionsClientITest extends AbstractStreamsITest {
     Source(1 to retryCount)
       .throttle(1, retryDelay, 1, Shaping)
       .mapAsync(1)(_ => client.fetchProjectionDetails(name))
-      .takeWhile(_ != expectedStatus)
+      .takeWhile(pd => !pd.map(_.status).contains(expectedStatus))
       .runFold(0) { case (sum, _) => sum + 1 }
       .map(failedCount => failedCount != retryCount)
   }

--- a/src/test/scala/eventstore/SoftDeleteStreamITest.scala
+++ b/src/test/scala/eventstore/SoftDeleteStreamITest.scala
@@ -48,8 +48,8 @@ class SoftDeleteStreamITest extends TestConnection {
 
     "preserve metadata except $tb when recreated" in new SoftDeleteScope {
       appendEventToCreateStream()
-      // Int.MaxValue = 2147483647
-      writeMetadata("""{"$tb":2147483647,"test":"test"}""")
+      // Long.MaxValue = 9223372036854775807
+      writeMetadata("""{"$tb":9223372036854775807,"test":"test"}""")
       appendEventToRecreate()
       readMetadata() mustEqual """{"$tb":1,"test":"test"}"""
     }

--- a/src/test/scala/eventstore/StreamPublisherSpec.scala
+++ b/src/test/scala/eventstore/StreamPublisherSpec.scala
@@ -102,7 +102,7 @@ class StreamPublisherSpec extends AbstractSubscriptionActorSpec {
     "catch events that appear in between reading and subscribing" in new SubscriptionScope {
       connection expectMsg readEvents(0)
 
-      val position = 1
+      val position = 1L
       actor ! readCompleted(2, false, event0, event1)
 
       expectEvent(event0)
@@ -157,7 +157,7 @@ class StreamPublisherSpec extends AbstractSubscriptionActorSpec {
     "stop catching events that appear in between reading and subscribing if stop received" in new SubscriptionScope {
       connection expectMsg readEvents(0)
 
-      val position = 1
+      val position = 1L
       actor ! readCompleted(2, false, event0, event1)
 
       expectEvent(event0)
@@ -183,7 +183,7 @@ class StreamPublisherSpec extends AbstractSubscriptionActorSpec {
     }
 
     "continue with subscription if no events appear in between reading and subscribing" in new SubscriptionScope {
-      val position = 0
+      val position = 0L
       connection expectMsg readEvents(position)
       actor ! readCompleted(position, endOfStream = true)
 
@@ -200,7 +200,7 @@ class StreamPublisherSpec extends AbstractSubscriptionActorSpec {
 
     "continue with subscription if no events appear in between reading and subscribing and position is given" in
       new SubscriptionScope {
-        val position = 1
+        val position = 1L
         connection expectMsg readEvents(position)
 
         actor ! readCompleted(position, endOfStream = true)
@@ -216,7 +216,7 @@ class StreamPublisherSpec extends AbstractSubscriptionActorSpec {
       }
 
     "forward events while subscribed" in new SubscriptionScope {
-      val position = 0
+      val position = 0L
       connection expectMsg readEvents(position)
       actor ! readCompleted(position, endOfStream = true)
 
@@ -513,12 +513,12 @@ class StreamPublisherSpec extends AbstractSubscriptionActorSpec {
       expectMsg(OnNext(x))
     }
 
-    def newEvent(number: Int): Event = EventRecord(streamId, EventNumber.Exact(number), mock[EventData])
+    def newEvent(number: Long): Event = EventRecord(streamId, EventNumber.Exact(number), mock[EventData])
 
-    def readEvents(x: Int) =
+    def readEvents(x: Long) =
       ReadStreamEvents(streamId, EventNumber(x), readBatchSize, Forward, resolveLinkTos = resolveLinkTos)
 
-    def readCompleted(next: Int, endOfStream: Boolean, events: Event*) = ReadStreamEventsCompleted(
+    def readCompleted(next: Long, endOfStream: Boolean, events: Event*) = ReadStreamEventsCompleted(
       events = events.toList,
       nextEventNumber = EventNumber(next),
       lastEventNumber = mock[EventNumber.Exact],
@@ -527,7 +527,7 @@ class StreamPublisherSpec extends AbstractSubscriptionActorSpec {
       direction = Forward
     )
 
-    def subscribeCompleted(x: Int) = SubscribeToStreamCompleted(x.toLong, Some(EventNumber.Exact(x)))
+    def subscribeCompleted(x: Long) = SubscribeToStreamCompleted(x.toLong, Some(EventNumber.Exact(x)))
 
     override def expectTerminatedOnFailure() = {
       val failure = new ServerErrorException("test")

--- a/src/test/scala/eventstore/StreamSubscriptionActorSpec.scala
+++ b/src/test/scala/eventstore/StreamSubscriptionActorSpec.scala
@@ -99,7 +99,7 @@ class StreamSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
     "catch events that appear in between reading and subscribing" in new SubscriptionScope {
       connection expectMsg readEvents(0)
 
-      val position = 1
+      val position = 1L
       actor ! readCompleted(2, false, event0, event1)
 
       expectEvent(event0)
@@ -154,7 +154,7 @@ class StreamSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
     "stop catching events that appear in between reading and subscribing if stop received" in new SubscriptionScope {
       connection expectMsg readEvents(0)
 
-      val position = 1
+      val position = 1L
       actor ! readCompleted(2, false, event0, event1)
 
       expectEvent(event0)
@@ -179,7 +179,7 @@ class StreamSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
     }
 
     "continue with subscription if no events appear in between reading and subscribing" in new SubscriptionScope {
-      val position = 0
+      val position = 0L
       connection expectMsg readEvents(position)
       actor ! readCompleted(position, endOfStream = true)
 
@@ -198,7 +198,7 @@ class StreamSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
 
     "continue with subscription if no events appear in between reading and subscribing and position is given" in
       new SubscriptionScope {
-        val position = 1
+        val position = 1L
         connection expectMsg readEvents(position)
 
         actor ! readCompleted(position, endOfStream = true)
@@ -216,7 +216,7 @@ class StreamSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
       }
 
     "forward events while subscribed" in new SubscriptionScope {
-      val position = 0
+      val position = 0L
       connection expectMsg readEvents(position)
       actor ! readCompleted(position, endOfStream = true)
 
@@ -424,12 +424,12 @@ class StreamSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
 
     def expectEvent(x: Event) = expectMsg(x)
 
-    def newEvent(number: Int): Event = EventRecord(streamId, EventNumber.Exact(number), mock[EventData])
+    def newEvent(number: Long): Event = EventRecord(streamId, EventNumber.Exact(number), mock[EventData])
 
-    def readEvents(x: Int) =
+    def readEvents(x: Long) =
       ReadStreamEvents(streamId, EventNumber(x), readBatchSize, Forward, resolveLinkTos = resolveLinkTos)
 
-    def readCompleted(next: Int, endOfStream: Boolean, events: Event*) = ReadStreamEventsCompleted(
+    def readCompleted(next: Long, endOfStream: Boolean, events: Event*) = ReadStreamEventsCompleted(
       events = events.toList,
       nextEventNumber = EventNumber(next),
       lastEventNumber = mock[EventNumber.Exact],
@@ -438,6 +438,6 @@ class StreamSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
       direction = Forward
     )
 
-    def subscribeCompleted(x: Int) = SubscribeToStreamCompleted(x.toLong, Some(EventNumber.Exact(x)))
+    def subscribeCompleted(x: Long) = SubscribeToStreamCompleted(x.toLong, Some(EventNumber.Exact(x)))
   }
 }

--- a/src/test/scala/eventstore/SubscribeITest.scala
+++ b/src/test/scala/eventstore/SubscribeITest.scala
@@ -18,7 +18,7 @@ class SubscribeITest extends TestConnection {
     "succeed for deleted stream but should not receive any events" in new SubscribeScope {
       appendEventToCreateStream()
       deleteStream()
-      subscribeToStream().lastEventNumber must beSome(EventNumber(Int.MaxValue)) // TODO WHY?
+      subscribeToStream().lastEventNumber must beSome(EventNumber(Long.MaxValue)) // TODO WHY?
     }
 
     "be able to subscribe to non existing stream and then catch new event" in new SubscribeScope {
@@ -30,7 +30,7 @@ class SubscribeITest extends TestConnection {
         case (event, index) =>
           val indexedEvent = expectStreamEventAppeared()
           indexedEvent.position.commitPosition must >(subscribed.lastCommit)
-          indexedEvent.event mustEqual EventRecord(streamId, EventNumber.Exact(index), event, Some(date))
+          indexedEvent.event mustEqual EventRecord(streamId, EventNumber.Exact(index.toLong), event, Some(date))
       }
     }
 

--- a/src/test/scala/eventstore/TestConnection.scala
+++ b/src/test/scala/eventstore/TestConnection.scala
@@ -48,7 +48,7 @@ abstract class TestConnection extends util.ActorSpec {
       val range = completed.numbersRange
       if (expectedVersion == ExpectedVersion.NoStream) events match {
         case Nil => range must beNone
-        case xs  => range must beSome(EventNumber.First to EventNumber.Exact(xs.size - 1))
+        case xs  => range must beSome(EventNumber.First to EventNumber.Exact(xs.size - 1L))
       }
       range
     }

--- a/src/test/scala/eventstore/WriteEventsITest.scala
+++ b/src/test/scala/eventstore/WriteEventsITest.scala
@@ -71,7 +71,7 @@ class WriteEventsITest extends TestConnection {
       val size = 100
       appendMany(size = size)
       actor ! ReadStreamEvents(streamId, EventNumber.Last, 1, ReadDirection.Backward)
-      expectMsgType[ReadStreamEventsCompleted].events.head.number mustEqual EventNumber(size - 1)
+      expectMsgType[ReadStreamEventsCompleted].events.head.number mustEqual EventNumber(size - 1L)
       deleteStream()
     }
 
@@ -82,7 +82,7 @@ class WriteEventsITest extends TestConnection {
       Seq.fill(n)(TestProbe()).foreach(x => appendMany(size = size, testKit = x))
 
       actor ! ReadStreamEvents(streamId, EventNumber.Last, 1, ReadDirection.Backward)
-      expectMsgType[ReadStreamEventsCompleted].events.head.number mustEqual EventNumber(size * n - 1)
+      expectMsgType[ReadStreamEventsCompleted].events.head.number mustEqual EventNumber(size * n - 1L)
 
       deleteStream()
     }
@@ -95,8 +95,8 @@ class WriteEventsITest extends TestConnection {
       val expected = for {
         x <- 0 until n
       } yield {
-        actor ! WriteEvents(streamId, List(newEventData), ExpectedVersion.Exact(x))
-        EventNumber(x + 1)
+        actor ! WriteEvents(streamId, List(newEventData), ExpectedVersion.Exact(x.toLong))
+        EventNumber(x + 1L)
       }
 
       val actual = for {

--- a/src/test/scala/eventstore/j/EsConnectionSpec.scala
+++ b/src/test/scala/eventstore/j/EsConnectionSpec.scala
@@ -303,7 +303,7 @@ class EsConnectionSpec extends util.ActorSpec {
       def onLiveProcessingStart(subscription: Closeable) = client.ref ! LiveProcessingStart
     }
 
-    def newEvent(x: Int) = IndexedEvent(EventRecord(streamId, EventNumber.Exact(x), EventData("event-type")), Position.Exact(x.toLong))
+    def newEvent(x: Long) = IndexedEvent(EventRecord(streamId, EventNumber.Exact(x), EventData("event-type")), Position.Exact(x))
 
     val error = new RuntimeException("test")
 

--- a/src/test/scala/eventstore/operations/IdentifyClientInspectionSpec.scala
+++ b/src/test/scala/eventstore/operations/IdentifyClientInspectionSpec.scala
@@ -1,0 +1,20 @@
+package eventstore
+package operations
+
+import org.specs2.mutable.Specification
+import eventstore.operations.Inspection.Decision.{ Stop, Fail }
+import scala.util.{ Failure, Success }
+
+class IdentifyClientInspectionSpec extends Specification {
+
+  val inspection = IdentifyClientInspection.pf
+
+  "IdentifyClientInspection" should {
+
+    "handle ClientIdentified" in {
+      inspection(Success(ClientIdentified)) mustEqual Stop
+    }
+
+  }
+
+}

--- a/src/test/scala/eventstore/util/ActorSpec.scala
+++ b/src/test/scala/eventstore/util/ActorSpec.scala
@@ -21,9 +21,9 @@ abstract class ActorSpec extends Specification with AfterAll {
 
   protected abstract class ActorScope extends TestKit(system) with ImplicitSender with Scope
 
-  def await_[T](awaitable: Awaitable[T], atMost: Duration = 3.seconds): T = awaitable.await_(atMost)
+  def await_[T](awaitable: Awaitable[T], atMost: Duration = 6.seconds): T = awaitable.await_(atMost)
 
   implicit class RichAwaitable[T](val awaitable: Awaitable[T]) {
-    def await_(implicit atMost: Duration = 3.seconds) = Await.result(awaitable, atMost)
+    def await_(implicit atMost: Duration = 6.seconds) = Await.result(awaitable, atMost)
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.1.2-SNAPSHOT"
+version in ThisBuild := "4.2.0-SNAPSHOT"


### PR DESCRIPTION
 - change protobuf definitions to use int64 instead
   of int32 in order to move along with eventstore
   protocol. Adjustments have been accordingly done
   with regards to `Long` vs. `Int` widening and
   signatures for `EventNumber`.

 - add test factor for akka in order to make slow
   CI runs more robust.

 - add `IdentifyClient` and `ClientIdentified` messages
   with corresponding marshalling and inspection/operations.

 - add new setting for client name.

 - update read me to reflect that ES client from now on
   only supports ES 4.0.0+.

 - adjust tests to account for ES client identification.

 - bump various dependencies.
 - downgrade spec2 as 3.8.7+ has concurrency issues.