### PR TITLE
[Dsl] first draft of stream dsl

### DIFF
--- a/src/main/scala/eventstore/dsl/EsConnectionExtension.scala
+++ b/src/main/scala/eventstore/dsl/EsConnectionExtension.scala
@@ -1,0 +1,34 @@
+package eventstore.dsl
+
+import eventstore.{ EsConnection, EventStream }
+
+object EsConnectionExtension {
+
+  implicit class EsConnectionPimper(val connection: EsConnection) extends AnyVal {
+    def getStream(name: String): EsStream = {
+      require(name != null, "Name cannot be null")
+      require(!name.isEmpty, "Name cannot be empty")
+
+      getStream(EventStream.Id(s"$name"))
+    }
+
+    def getStream(streamId: EventStream.Id): EsStream = new EsStream(connection, streamId)
+
+    def getStreamAs[T](name: String)(implicit eventFormat: EventFormat[T]): EsStreamAs[T] = {
+      require(name != null, "Name cannot be null")
+      require(!name.isEmpty, "Name cannot be empty")
+
+      getStreamAs(EventStream.Id(s"$name"))
+    }
+
+    def getStreamAs[T](streamId: EventStream.Id)(implicit eventFormat: EventFormat[T]): EsStreamAs[T] = new EsStreamAs(connection, streamId, eventFormat)
+
+    def getStreamCategory(category: String): EsStreamCategory = {
+      new EsStreamCategory(connection, category)
+    }
+
+    def getStreamCategoryAs[T](category: String)(implicit eventFormat: EventFormat[T]): EsStreamCategoryAs[T] = {
+      new EsStreamCategoryAs[T](connection, category)
+    }
+  }
+}

--- a/src/main/scala/eventstore/dsl/EsStreams.scala
+++ b/src/main/scala/eventstore/dsl/EsStreams.scala
@@ -1,0 +1,294 @@
+package eventstore.dsl
+
+import java.util.UUID
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.{ Done, NotUsed }
+import eventstore._
+import eventstore.dsl.WriteStream.WriteStreamError
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+trait ReadStreamAs[T] extends BaseReadStream {
+
+  protected[this] implicit val eventReader: EventReader[T]
+
+  def subscribe(startOffset: Offset = Offset.First): ReadAllAs[T] = read(startOffset, infinite = true)
+
+  def read(startOffset: Offset = Offset.First, infinite: Boolean = false): ReadAllAs[T] = ReadAllAs[T](doRead(startOffset, infinite))
+
+  def readOne(offset: Offset)(implicit ec: ExecutionContext): ReadOneAs[T] = ReadOneAs[T](doReadOne(offset))
+
+  def last()(implicit ec: ExecutionContext): ReadOneAs[T] = ReadOneAs[T](doLast())
+
+  def first()(implicit ec: ExecutionContext): ReadOneAs[T] = ReadOneAs[T](doFirst())
+
+  def firstOffset()(implicit ec: ExecutionContext): ReadOffset = new ReadOffset(doFirstOffset())
+
+  def lastOffset()(implicit ec: ExecutionContext): ReadOffset = new ReadOffset(doLastOffset())
+}
+
+trait ReadStream extends BaseReadStream {
+
+  def subscribe(startOffset: Offset = Offset.First): ReadAll = read(startOffset, infinite = true)
+
+  def read(startOffset: Offset = Offset.First, infinite: Boolean = false): ReadAll = new ReadAll(doRead(startOffset, infinite))
+
+  def readOne(offset: Offset)(implicit ec: ExecutionContext): ReadOne = new ReadOne(doReadOne(offset))
+
+  def last()(implicit ec: ExecutionContext): ReadOne = new ReadOne(doLast())
+
+  def first()(implicit ec: ExecutionContext): ReadOne = new ReadOne(doFirst())
+
+  def firstOffset()(implicit ec: ExecutionContext): ReadOffset = new ReadOffset(doFirstOffset())
+
+  def lastOffset()(implicit ec: ExecutionContext): ReadOffset = new ReadOffset(doLastOffset())
+}
+
+sealed trait BaseReadStream extends Stream {
+
+  protected[this] def doRead(startOffset: Offset = Offset.First, infinite: Boolean = false): Source[Event, NotUsed] = {
+
+    def toNumberExclusive: Option[EventNumber] = {
+      if (startOffset == Offset.First) Option.empty
+      else Some(EventNumber.Exact((startOffset.value - 1).toInt))
+    }
+
+    val publisher = connection.streamPublisher(
+      streamId = streamId,
+      fromNumberExclusive = toNumberExclusive,
+      infinite = infinite
+    )
+    Source.fromPublisher(publisher)
+  }
+
+  protected[this] def doReadOne(offset: Offset)(implicit ec: ExecutionContext): Future[Event] = {
+    readAt(EventNumber.Exact(offset.value.toInt))
+  }
+
+  protected[this] def doLast()(implicit ec: ExecutionContext): Future[Event] = {
+    readAt(EventNumber.Last)
+  }
+
+  protected[this] def doFirst()(implicit ec: ExecutionContext): Future[Event] = {
+    readAt(EventNumber.First)
+  }
+
+  protected[this] def doFirstOffset()(implicit ec: ExecutionContext): Future[Offset] = {
+    readOffsetAt(EventNumber.First)
+  }
+
+  protected[this] def readOffsetAt(eventNumber: EventNumber)(implicit ec: ExecutionContext): Future[Offset] = {
+    for {
+      event <- readAt(eventNumber)
+    } yield Offset(event.record.number.value.toLong)
+  }
+
+  protected[this] def readAt(eventNumber: EventNumber)(implicit ec: ExecutionContext): Future[Event] = {
+    val readCommand = ReadEvent(streamId, eventNumber)
+    connection(readCommand).map { e => e.event }
+  }
+
+  protected[this] def doLastOffset()(implicit ec: ExecutionContext): Future[Offset] = {
+    readOffsetAt(EventNumber.Last)
+  }
+
+}
+
+object ReadStream {
+
+  sealed trait ReadStreamError
+
+  case class ReadStreamFailure(ex: EsException) extends ReadStreamError
+
+  case class UnsupportedEventFailure(event: Event, cause: Throwable) extends ReadStreamError
+
+}
+
+trait MetadataStream extends Stream {
+
+  def writeMetadata[T](metadata: T)(implicit mf: MetadataWriter[T], ec: ExecutionContext): Future[Unit] = {
+    connection
+      .setStreamMetadata(streamId, mf.write(metadata))
+      .map(_ => ())
+  }
+
+  def readMetadata()(implicit ec: ExecutionContext): ReadMetadata = {
+    new ReadMetadata(connection.getStreamMetadata(streamId))
+  }
+}
+
+object MetadataStream {
+
+  sealed trait ReadMetadataError
+
+  case class ReadMetadataFailure(ex: EsException) extends ReadMetadataError
+
+  case class UnsupportedMetadataFailure(content: Content, cause: Throwable) extends ReadMetadataError
+
+}
+
+trait WriteStreamAs[T] extends BaseWriteStream {
+  protected[this] implicit val eventWriter: EventWriter[T]
+
+  def append(events: T*)(implicit ec: ExecutionContext): Future[Either[WriteStreamError, WriteEventsCompleted]] = {
+    write[T](events = List(events: _*))
+  }
+
+  def appendSeq(events: Seq[T])(implicit ec: ExecutionContext): Future[Either[WriteStreamError, WriteEventsCompleted]] = {
+    write[T](events = events)
+  }
+
+  def appendAt(offset: Offset, events: T*)(implicit ec: ExecutionContext): Future[Either[WriteStreamError, WriteEventsCompleted]] = {
+    write[T](Some(offset), events)
+  }
+
+  def appendSeqAt(offset: Offset, events: Seq[T])(implicit ec: ExecutionContext): Future[Either[WriteStreamError, WriteEventsCompleted]] = {
+    write[T](Some(offset), events)
+  }
+}
+
+trait WriteStream extends BaseWriteStream {
+  def append[T](events: T*)(implicit ef: EventWriter[T], ec: ExecutionContext): Future[Either[WriteStreamError, WriteEventsCompleted]] = {
+    write[T](events = List(events: _*))
+  }
+
+  def appendSeq[T](events: Seq[T])(implicit ef: EventWriter[T], ec: ExecutionContext): Future[Either[WriteStreamError, WriteEventsCompleted]] = {
+    write[T](events = events)
+  }
+
+  def appendAt[T](offset: Offset, events: T*)(implicit ef: EventWriter[T], ec: ExecutionContext): Future[Either[WriteStreamError, WriteEventsCompleted]] = {
+    write[T](Some(offset), events)
+  }
+
+  def appendSeqAt[T](offset: Offset, events: Seq[T])(implicit ef: EventWriter[T], ec: ExecutionContext): Future[Either[WriteStreamError, WriteEventsCompleted]] = {
+    write[T](Some(offset), events)
+  }
+}
+
+object StreamImplicits {
+  implicit class WriteStreamImplicit(val future: Future[Either[WriteStreamError, WriteEventsCompleted]]) extends AnyVal {
+
+    def failOnError(implicit ec: ExecutionContext): Future[Done] = {
+      future.map {
+        case Left(error) => throw error.cause
+        case Right(_)    => Done
+      }
+    }
+  }
+
+}
+
+trait BaseWriteStream extends Stream {
+  import Recovery._
+
+  def delete(hardDelete: Boolean = false)(implicit ec: ExecutionContext): Future[Either[WriteStreamError, DeleteStreamCompleted]] = {
+    connection(DeleteStream(streamId, hard = hardDelete)).map(Right(_))
+      .recover(recoverAllEsExceptionForWrite)
+  }
+
+  protected[this] def write[T](startOffset: Option[Offset] = None, events: Seq[T])(implicit writer: EventWriter[T], ec: ExecutionContext): Future[Either[WriteStreamError, WriteEventsCompleted]] = {
+
+    val expectedVersion = startOffset match {
+      case None               => ExpectedVersion.Any
+      case Some(Offset.First) => ExpectedVersion.NoStream
+      case Some(offset)       => ExpectedVersion.Exact(offset.previous.get.value.toInt)
+    }
+
+    val writeCommand = WriteEvents(
+      expectedVersion = expectedVersion,
+      streamId = streamId,
+      events = events.map(writer.write).toList
+    )
+
+    connection(writeCommand)
+      .map(Right(_))
+      .recover(recoverAllEsExceptionForWrite)
+  }
+
+}
+
+object WriteStream {
+
+  sealed trait WriteStreamError {
+    val cause: Throwable
+  }
+
+  case class WriteStreamFailure(cause: EsException) extends WriteStreamError
+
+  case class UnsupportedWriteFailure(event: Event, cause: Throwable) extends WriteStreamError
+
+  object WriteStreamError {
+    def unapply(arg: WriteStreamError): Option[Throwable] = {
+      Some(arg match {
+        case WriteStreamFailure(cause)         => cause
+        case UnsupportedWriteFailure(_, cause) => cause
+      })
+    }
+  }
+
+}
+
+sealed trait Stream {
+  protected[this] val connection: EsConnection
+  protected val streamId: EventStream.Id
+}
+
+class EsStream(val connection: EsConnection, val streamId: EventStream.Id) extends Stream with ReadStream with WriteStream with MetadataStream
+
+class EsStreamAs[T](val connection: EsConnection, val streamId: EventStream.Id, _eventFormat: EventFormat[T])
+    extends Stream with ReadStreamAs[T] with WriteStreamAs[T] with MetadataStream {
+  protected[this] implicit val eventReader = _eventFormat
+  protected[this] implicit val eventWriter = _eventFormat
+}
+
+class EsStreamCategory(val connection: EsConnection, val category: String) extends BaseStreamCategory {
+  def withId(id: UUID): EsStream = {
+    withId(id.toString)
+  }
+
+  def withId(id: String): EsStream = {
+    require(Option(id).exists(_.nonEmpty), "Id cannot be empty")
+    new EsStream(connection, EventStream.Id(s"$category-$id"))
+  }
+}
+
+class EsStreamCategoryAs[T](val connection: EsConnection, val category: String)(implicit eventFormat: EventFormat[T]) extends BaseStreamCategory {
+  def withId(id: UUID): EsStreamAs[T] = {
+    withId(id.toString)
+  }
+
+  def withId(id: String): EsStreamAs[T] = {
+    require(Option(id).exists(_.nonEmpty), "Id cannot be empty")
+    new EsStreamAs[T](connection, EventStream.Id(s"$category-$id"), eventFormat)
+  }
+}
+
+trait BaseStreamCategory {
+  protected[this] val connection: EsConnection
+  protected[this] val category: String
+
+  require(!category.contains("-"), "Category name cannot contain '-'")
+  require(!category.contains("$"), "Category name cannot contain the '$' character")
+
+  def delete(hardDelete: Boolean = false)(implicit executionContext: ExecutionContext, materializer: Materializer): Future[Unit] = {
+
+    def extractCategoryName = (str: String) => str.split("-").headOption match {
+      case Some(categoryName) => categoryName
+      case None               => ""
+    }
+
+    val allStreamSource: Source[String, NotUsed] = Source.fromPublisher(
+      connection.allStreamsPublisher(fromPositionExclusive = Some(Position.Last), infinite = false)
+    )
+      .map(_.event.streamId.streamId)
+      .filter(streamName => extractCategoryName(streamName).equals(category))
+      .fold[Set[String]](Set())((streams, stream) => streams + stream)
+      .mapConcat(identity)
+
+    allStreamSource.mapAsync(1)(streamId => connection(DeleteStream(EventStream.Id(streamId), hard = hardDelete)))
+      .runWith(Sink.ignore)
+      .map(_ => ())
+  }
+}

--- a/src/main/scala/eventstore/dsl/Formats.scala
+++ b/src/main/scala/eventstore/dsl/Formats.scala
@@ -1,0 +1,231 @@
+package eventstore.dsl
+
+import java.util.UUID
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import eventstore.dsl.MetadataStream.{ ReadMetadataError, ReadMetadataFailure, UnsupportedMetadataFailure }
+import eventstore.dsl.ReadStream.{ ReadStreamError, ReadStreamFailure, UnsupportedEventFailure }
+import eventstore.dsl.WriteStream.{ WriteStreamError, WriteStreamFailure }
+import eventstore.{ Content, EsException, Event, EventData, EventNotFoundException, NonMetadataEventException, StreamDeletedException, StreamNotFoundException }
+import Recovery._
+import scala.annotation.implicitNotFound
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success, Try }
+
+trait EventFormat[T] extends EventReader[T] with EventWriter[T]
+
+@implicitNotFound("No member of type class EventReader in scope for ${T}")
+trait EventReader[T] {
+  def read(event: Event): EsEvent[T]
+  def supports(event: Event): Boolean
+}
+
+@implicitNotFound("No member of type class EventWriter in scope for ${T}")
+trait EventWriter[T] {
+  def write(data: T): EventData
+
+  def eventType(data: T): String
+
+  def eventId(data: T): UUID = {
+    val _ = data
+    UUID.randomUUID()
+  }
+}
+
+trait MetadataFormat[M] extends MetadataReader[M] with MetadataWriter[M]
+
+@implicitNotFound("No member of type class MetadataWriter in scope for ${M}")
+trait MetadataWriter[M] {
+  def write(metadata: M): Content
+}
+
+@implicitNotFound("No member of type class MetadataReader in scope for ${M}")
+trait MetadataReader[M] {
+  def read(content: Content): Option[M]
+}
+
+case class EsEvent[T](source: Event, payload: T) {
+  def offset: Offset = Offset(source.record.number.value.toLong)
+}
+
+class ReadAllAs[T](private val readAll: ReadAll)(implicit reader: EventReader[T]) {
+  def filter(matcher: (Event) => Boolean): Source[(Offset, Either[UnsupportedEventFailure, T]), NotUsed] = readAll.filter[T](matcher)
+  def getOnly: Source[(Offset, T), NotUsed] = readAll.onlyAs[T]
+  def get: Source[(Offset, Either[UnsupportedEventFailure, T]), NotUsed] = readAll.as[T]
+  def raw: Source[(Offset, Event), NotUsed] = readAll.raw
+}
+
+object ReadAllAs {
+  def apply[T](source: Source[Event, NotUsed])(implicit reader: EventReader[T]): ReadAllAs[T] = new ReadAllAs[T](new ReadAll(source))
+}
+
+class ReadAll(private val source: Source[Event, NotUsed]) extends Read {
+  def filter[T](matcher: (Event) => Boolean)(implicit reader: EventReader[T]): Source[(Offset, Either[UnsupportedEventFailure, T]), NotUsed] = {
+    source
+      .filter(matcher)
+      .map(readAs[T])
+  }
+
+  def raw: Source[(Offset, Event), NotUsed] = {
+    import Read._
+    source
+      .map(event => event.offset -> event)
+  }
+
+  def onlyAs[T](implicit reader: EventReader[T]): Source[(Offset, T), NotUsed] = {
+    as[T]
+      .collect { case (offset, Right(event)) => offset -> event }
+  }
+
+  def as[T](implicit reader: EventReader[T]): Source[(Offset, Either[UnsupportedEventFailure, T]), NotUsed] = {
+    source.map(readAs[T])
+  }
+}
+
+class ReadOneAs[T](private val readOne: ReadOne)(implicit reader: EventReader[T]) {
+  def raw(): Future[Either[ReadStreamError, Event]] = readOne.raw
+
+  def get(): Future[T] = {
+    readOne.as[T]
+  }
+
+  def getOpt(): Future[Option[T]] = {
+    readOne.asOpt[T]
+  }
+}
+
+object ReadOneAs {
+  def apply[T](future: Future[Event])(implicit reader: EventReader[T], executionContext: ExecutionContext): ReadOneAs[T] = new ReadOneAs[T](new ReadOne(future))
+}
+
+class ReadOne(private val future: Future[Event])(implicit executionContext: ExecutionContext) extends Read {
+
+  def raw: Future[Either[ReadStreamError, Event]] = future.map(Right(_)).recover(recoverAllEsExceptionForRead)
+
+  def as[T](implicit reader: EventReader[T]): Future[T] = asOpt[T].map(_.get)
+
+  def asOpt[T](implicit reader: EventReader[T]): Future[Option[T]] = {
+    future
+      .map(readAs[T])
+      .map {
+        case (_, Right(payload)) => Some(payload)
+        case (_, Left(_))        => None
+      }
+      .recover(recoverWhenStreamNotExist[T])
+  }
+}
+
+trait Read {
+
+  private[dsl] def readAs[T](event: Event)(implicit reader: EventReader[T]): (Offset, Either[UnsupportedEventFailure, T]) = {
+    import Read._
+    event.offset -> read(event).right.map(_.payload)
+  }
+
+  private[dsl] def read[T](event: Event)(implicit reader: EventReader[T]): Either[UnsupportedEventFailure, EsEvent[T]] = {
+    if (reader.supports(event)) {
+      Right(performRead(event))
+    } else {
+      Left(UnsupportedEventFailure(event, new IllegalArgumentException(s"EventReader don't support eventType : ${event.data.eventType}")))
+    }
+  }
+
+  private def performRead[T](event: Event)(implicit reader: EventReader[T]): EsEvent[T] = {
+    Try(reader.read(event)) match {
+      case Success(esEvent) => esEvent
+      case Failure(error)   => throw error
+    }
+  }
+}
+
+object Read {
+
+  implicit class PimpGetEventStoreEvent(val event: Event) extends AnyVal {
+    def offset = Offset(event.record.number.value.toLong)
+  }
+
+}
+
+class ReadOffset(private val future: Future[Offset])(implicit executionContext: ExecutionContext) {
+
+  /**
+   * Return the offset of the stream
+   *
+   * if the stream is a projection (with link event) you will get the link offset
+   *
+   * @return Successful Future with the offset value if the stream is valid
+   *         Failed Future if the stream is not valid
+   */
+  def get: Future[Offset] = future
+
+  def getAsLong: Future[Long] = future.map(_.value)
+
+  def getOptAsLong: Future[Option[Long]] = getOpt.map {
+    case Some(offset) => Some(offset.value)
+    case None         => None
+  }
+
+  /**
+   * Return an option offset of the stream
+   *
+   * if the stream is a stream which contains linkedEvent, we only returning
+   *
+   * @return Successful Future with the offset value if the stream is valid
+   *         Failed Future if the stream is not valid
+   */
+  def getOpt: Future[Option[Offset]] = {
+    future.map(Some(_)).recover(recoverWhenStreamNotExist[Offset])
+  }
+}
+
+class ReadMetadata(private val future: Future[Content])(implicit executionContext: ExecutionContext) {
+
+  def as[M](implicit ef: MetadataReader[M]): Future[Either[ReadMetadataError, M]] = {
+    future.map(content => read(content).right.map(_.get))
+      .recover(recoverAllEsException)
+  }
+
+  private def recoverAllEsException[M]: PartialFunction[Throwable, Either[ReadMetadataError, M]] = {
+    case ex: EsException => Left(ReadMetadataFailure(ex))
+  }
+
+  def asOpt[M](implicit ef: MetadataReader[M]): Future[Option[M]] = {
+    future.map(content => read(content) match {
+      case Right(optMetadata) => optMetadata
+      case Left(_)            => None
+    })
+      .recover(
+        recoverWhenStreamNotExist[M].orElse {
+          case _: NonMetadataEventException => None
+        }
+      )
+  }
+
+  private def read[M](content: Content)(implicit reader: MetadataReader[M]): Either[UnsupportedMetadataFailure, Option[M]] = {
+    Try(reader.read(content)) match {
+      case Success(optMetadata) => Right(optMetadata)
+      case Failure(error)       => Left(UnsupportedMetadataFailure(content, error))
+    }
+  }
+}
+
+object Recovery {
+  private[dsl] def recoverWhenStreamNotExist[T]: PartialFunction[Throwable, Option[T]] = {
+    case _: StreamNotFoundException => None
+    case _: StreamDeletedException  => None
+    case _: EventNotFoundException  => None
+  }
+
+  private[dsl] def recoverAllEsExceptionForRead[T]: PartialFunction[Throwable, Either[ReadStreamError, T]] = {
+    case ex: EsException => Left(ReadStreamFailure(ex))
+  }
+
+  private[dsl] def recoverAllEsExceptionForWrite[T]: PartialFunction[Throwable, Either[WriteStreamError, T]] = {
+    case ex: EsException => Left(WriteStreamFailure(ex))
+  }
+
+  private[dsl] def recoverAllEsExceptionForReadMetadata[T]: PartialFunction[Throwable, Either[ReadMetadataError, T]] = {
+    case ex: EsException => Left(ReadMetadataFailure(ex))
+  }
+}

--- a/src/main/scala/eventstore/dsl/Offset.scala
+++ b/src/main/scala/eventstore/dsl/Offset.scala
@@ -1,0 +1,69 @@
+package eventstore.dsl
+
+import spray.json.{ JsNumber, JsValue, JsonFormat, deserializationError }
+
+class Offset private (val value: Long) extends AnyVal with Ordered[Offset] {
+
+  //noinspection ScalaStyle
+  def +(increment: Long): Offset = Offset(this.value + increment)
+
+  //noinspection ScalaStyle
+  def -(decrement: Long): Offset = Offset(this.value - decrement)
+
+  //noinspection ScalaStyle
+  def +(increment: Int): Offset = Offset(this.value + increment)
+
+  //noinspection ScalaStyle
+  def -(decrement: Int): Offset = Offset(this.value - decrement)
+
+  def next: Offset = Offset(value + 1)
+
+  def previous: Option[Offset] = {
+    if (this == Offset.First) {
+      None
+    } else {
+      Some(Offset(value - 1))
+    }
+  }
+
+  def until(exclusive: Offset): IndexedSeq[Offset] = value.until(exclusive.value).map(Offset.apply)
+
+  def compare(that: Offset): Int = value.compare(that.value)
+
+  def min(other: Offset): Offset = {
+    if (this < other) this
+    else other
+  }
+
+  def max(other: Offset): Offset = {
+    if (this >= other) this
+    else other
+  }
+
+  override def toString: String = s"Offset($value)"
+}
+
+object Offset {
+  val First = Offset(0)
+  val MaxValue = Offset(Long.MaxValue)
+
+  def apply(value: Int): Offset = {
+    apply(value.toLong)
+  }
+
+  def apply(value: Long): Offset = {
+    require(value >= 0, s"The offset value : '$value' is not allow")
+    new Offset(value)
+  }
+
+  def unapply(arg: Offset): Option[Long] = Some(arg.value)
+
+  implicit val offsetJsonFormat = new JsonFormat[Offset] {
+    def read(json: JsValue): Offset = json match {
+      case JsNumber(value) if value >= 0 && value.isValidLong => Offset(value.toLongExact)
+      case JsNumber(value) => deserializationError(s"Offset value must be >=0 but got $value")
+      case other => deserializationError(s"Tried to deserialized an Offset while the input is $other")
+    }
+    def write(obj: Offset): JsValue = JsNumber(obj.value)
+  }
+}

--- a/src/main/scala/eventstore/dsl/supports/ADTJsonFormat.scala
+++ b/src/main/scala/eventstore/dsl/supports/ADTJsonFormat.scala
@@ -1,0 +1,44 @@
+package eventstore.dsl.supports
+
+import spray.json.{ DefaultJsonProtocol, JsObject, JsString, JsValue, JsonFormat, RootJsonFormat, _ }
+
+/**
+ * Json format for all subtypes of an ADT.
+ * This format expects each subtype to have its own JsonFormat.
+ * It delegates reading and writing to the proper JsonFormat depending on the object subtype determined using :
+ *  - The #{getObjectType} function to get the type from an instance when writing to json
+ *  - The #{typeFieldName} field in the json when reading from json
+ *
+ * @param typeFieldName the field to read/write in the json to extract the object subtype
+ * @param getObjectType function that returns the object type from a T
+ * @param subTypeJsonFormatsMap the map of the jsonFormat for all supported subtypes of T
+ * @param outputType whether this format should add the typeFieldName to the json or not (default to true)
+ * @tparam T the base type of the ADT
+ */
+class ADTJsonFormat[T](
+  typeFieldName:         String,
+  getObjectType:         T => String,
+  subTypeJsonFormatsMap: Map[String, JsonFormat[_ <: T]],
+  outputType:            Boolean                         = true
+) extends RootJsonFormat[T] {
+  import DefaultJsonProtocol._
+
+  def jsonFormatForType(elementType: String): JsonFormat[T] = subTypeJsonFormatsMap
+    .getOrElse(elementType, deserializationError(s"Trying to fetch the format for an unsupported eventType : $elementType"))
+    .asInstanceOf[JsonFormat[T]]
+
+  override def read(json: JsValue): T = json.asJsObject.getFields(typeFieldName).map(_.convertTo[String]) match {
+    case Seq(eventType) => jsonFormatForType(eventType).read(json)
+    case x              => deserializationError(s"Expected event to contain eventType, but found $x")
+  }
+
+  override def write(obj: T): JsValue = {
+    val jsonFormat = jsonFormatForType(getObjectType(obj))
+    val jsObject = jsonFormat.write(obj).asJsObject
+    if (outputType) {
+      JsObject(Map(typeFieldName -> JsString(getObjectType(obj))) ++ jsObject.fields)
+    } else {
+      jsObject
+    }
+  }
+}

--- a/src/main/scala/eventstore/dsl/supports/SprayJsonEventFormats.scala
+++ b/src/main/scala/eventstore/dsl/supports/SprayJsonEventFormats.scala
@@ -1,0 +1,107 @@
+package eventstore.dsl.supports
+
+import java.util.UUID
+
+import eventstore.dsl.{ EsEvent, EventFormat, EventReader, EventWriter }
+import eventstore.{ Content, Event, EventData }
+import spray.json._
+
+import scala.reflect.ClassTag
+import scala.util.control.Exception._
+
+trait SprayJsonFormatsExtension {
+  implicit object JavaUUIDFormat extends JsonFormat[UUID] {
+    override def write(obj: UUID): JsValue = JsString(obj.toString)
+
+    override def read(json: JsValue): UUID = json match {
+      case JsString(value) =>
+        catching(classOf[IllegalArgumentException])
+          .opt(UUID.fromString(value))
+          .getOrElse(deserializationError(s"Expected UUID, but got: $value"))
+
+      case x => deserializationError(s"Java UUID : Expected UUID, but got $x")
+    }
+  }
+}
+
+object SprayJsonFormatsExtension extends SprayJsonFormatsExtension
+
+object SprayJsonEventFormats {
+  trait JsonEventReader[T] extends EventReader[T] {
+    implicit val eventClassTag: ClassTag[T]
+
+    final def read(event: Event): EsEvent[T] = {
+      event.data.data match {
+        case Content.Json(jsonValue) => EsEvent(event, doRead(event, jsonValue))
+        case notSupported            => deserializationError(s"Only json format is supported : ${notSupported.contentType}")
+      }
+    }
+
+    def doRead(source: Event, json: String): T
+
+    def supports(event: Event): Boolean = event.data.eventType == implicitly[ClassTag[T]].runtimeClass.getSimpleName
+  }
+
+  class SprayJsonEventReader[T: JsonReader](implicit val eventClassTag: ClassTag[T]) extends JsonEventReader[T] {
+    def doRead(source: Event, json: String): T = json.parseJson.convertTo[T]
+  }
+
+  trait JsonEventWriter[T] extends EventWriter[T] {
+    private val specialCharacters = List("$", "%", "_", " ", "#")
+
+    final def write(data: T): EventData = {
+      EventData(eventType(data), eventId(data), data = Content.Json(doWrite(data)))
+    }
+
+    def eventType(data: T): String = {
+      val eventType = data.getClass.getSimpleName
+      require(!specialCharacters.exists(eventType.contains), s"An event type should never contains special characters ($specialCharacters) $eventType")
+      eventType
+    }
+
+    def doWrite(data: T): String
+  }
+
+  class SprayJsonEventWriter[T: JsonWriter] extends JsonEventWriter[T] {
+    def doWrite(data: T): String = data.toJson.asJsObject.compactPrint
+  }
+
+  trait JsonEventFormat[T] extends EventFormat[T] with JsonEventReader[T] with JsonEventWriter[T]
+
+  class SprayJsonEventFormat[T: JsonFormat](implicit val eventClassTag: ClassTag[T]) extends JsonEventFormat[T] {
+    def doWrite(data: T): String = data.toJson.asJsObject.compactPrint
+    def doRead(source: Event, json: String): T = json.parseJson.convertTo[T]
+  }
+
+  class AdtSprayJsonEventFormat[T](subTypeJsonFormatsMap: Map[String, JsonFormat[_ <: T]])(implicit val eventClassTag: ClassTag[T]) extends JsonEventFormat[T] {
+    override def doWrite(data: T): String = {
+      subTypeJsonFormatsMap
+        .getOrElse(eventType(data), throw new IllegalArgumentException(s"Trying to write unsupported event type ${eventType(data)}"))
+        .asInstanceOf[JsonFormat[T]]
+        .write(data)
+        .asJsObject
+        .compactPrint
+    }
+
+    override def doRead(source: Event, json: String): T = {
+      val eventType = source.data.eventType
+      subTypeJsonFormatsMap
+        .getOrElse(eventType, throw new IllegalArgumentException(s"Trying to write unsupported event type ${eventType}"))
+        .asInstanceOf[JsonFormat[T]]
+        .read(json.parseJson)
+    }
+
+    override def supports(event: Event): Boolean = subTypeJsonFormatsMap.keySet.contains(event.data.eventType)
+  }
+
+  def reader[T: JsonReader: ClassTag]: JsonEventReader[T] = new SprayJsonEventReader[T]
+
+  def writer[T: JsonWriter]: JsonEventWriter[T] = new SprayJsonEventWriter[T]
+
+  def format[T: JsonFormat: ClassTag]: JsonEventFormat[T] = new SprayJsonEventFormat[T]
+
+  def adtFormat[T: ClassTag](subTypeJsonFormatsMap: Map[String, JsonFormat[_ <: T]]): JsonEventFormat[T] =
+    new AdtSprayJsonEventFormat[T](subTypeJsonFormatsMap)
+
+}
+

--- a/src/main/scala/eventstore/dsl/supports/SprayJsonMetadataFormats.scala
+++ b/src/main/scala/eventstore/dsl/supports/SprayJsonMetadataFormats.scala
@@ -1,0 +1,44 @@
+package eventstore.dsl.supports
+
+import eventstore.Content
+import eventstore.dsl.{ MetadataFormat, MetadataReader, MetadataWriter }
+import spray.json._
+
+object SprayJsonMetadataFormats {
+  trait SprayJsonMetadataReaderLike[M] extends MetadataReader[M] {
+    implicit val jsonReader: JsonReader[M]
+
+    def read(content: Content): Option[M] = content match {
+      case Content.Json(jsValue) =>
+        val payload = jsValue.parseJson.asInstanceOf[JsObject]
+        Some(doRead(payload))
+      case contentNotSupported => deserializationError(s"Only json format is supported : $contentNotSupported")
+    }
+
+    def doRead(event: JsObject): M = event.convertTo[M]
+  }
+
+  class SprayJsonMetadataReader[M](implicit val jsonReader: JsonReader[M]) extends SprayJsonMetadataReaderLike[M]
+
+  trait SprayJsonMetadataWriterLike[M] extends MetadataWriter[M] {
+    implicit val jsonWriter: JsonWriter[M]
+
+    def write(data: M): Content = {
+      val json = doWrite(data)
+      Content.Json(json.compactPrint)
+    }
+
+    def doWrite(data: M): JsObject = data.toJson.asJsObject
+  }
+
+  class SprayJsonMetadataWriter[M](implicit val jsonWriter: JsonWriter[M]) extends SprayJsonMetadataWriterLike[M]
+
+  class SprayJsonMetadataFormat[M](implicit val jsonReader: JsonReader[M], val jsonWriter: JsonWriter[M])
+    extends MetadataFormat[M] with SprayJsonMetadataReaderLike[M] with SprayJsonMetadataWriterLike[M]
+
+  def reader[M](implicit reader: JsonReader[M]): SprayJsonMetadataReader[M] = new SprayJsonMetadataReader[M]
+
+  def writer[M](implicit writer: JsonWriter[M]): SprayJsonMetadataWriter[M] = new SprayJsonMetadataWriter[M]
+
+  def format[M](implicit jsonFormat: JsonFormat[M]): SprayJsonMetadataFormat[M] = new SprayJsonMetadataFormat[M]
+}

--- a/src/test/scala/eventstore/dsl/EsStreamsAsITest.scala
+++ b/src/test/scala/eventstore/dsl/EsStreamsAsITest.scala
@@ -1,0 +1,351 @@
+package eventstore.dsl
+
+import java.util.UUID
+
+import akka.Done
+import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.scaladsl.{ Sink, Source }
+import eventstore.dsl.EsStreamsAsSpec.jsonFormat1
+import eventstore.dsl.supports.SprayJsonFormatsExtension._
+import eventstore.dsl.supports.{ SprayJsonEventFormats, SprayJsonMetadataFormats }
+import eventstore.{ EventData, _ }
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+sealed trait Book extends Product
+object Book {
+  val MapJsonFormat = Map(
+    classOf[SciFiBook].getSimpleName -> SciFiBook.JsonFormat,
+    classOf[FinanceBook].getSimpleName -> FinanceBook.JsonFormat,
+    classOf[GodBook].getSimpleName -> GodBook.JsonFormat
+  )
+}
+
+case class SciFiBook(id: UUID = UUID.randomUUID(), name: String, author: String = "") extends Book
+
+object SciFiBook {
+  implicit val JsonFormat = jsonFormat3(SciFiBook.apply)
+}
+
+case class FinanceBook(id: UUID = UUID.randomUUID(), name: String, author: String = "") extends Book
+
+object FinanceBook {
+  implicit val JsonFormat = jsonFormat3(FinanceBook.apply)
+}
+
+case class GodBook(id: UUID = UUID.randomUUID(), name: String) extends Book
+
+object GodBook {
+  implicit val JsonFormat = jsonFormat2(GodBook.apply)
+}
+
+case class CustomBookMetadata(text: String)
+
+object CustomBookMetadata {
+  implicit val JsonFormat = jsonFormat1(CustomBookMetadata.apply)
+}
+
+object EsStreamsAsSpec extends DefaultJsonProtocol {
+
+  implicit val sciFiBookEventFormat = SprayJsonEventFormats.format[SciFiBook]
+
+  implicit val financeBookEventFormat = SprayJsonEventFormats.format[FinanceBook]
+
+  implicit val godBookEventFormat = SprayJsonEventFormats.format[GodBook]
+
+  implicit val bookEventFormat = SprayJsonEventFormats.adtFormat[Book](Book.MapJsonFormat)
+
+  implicit val customMetadataMetaFormat = SprayJsonMetadataFormats.format[CustomBookMetadata]
+}
+
+class EsStreamsAsSpec extends TestConnection {
+
+  import EsConnectionExtension._
+  import EsStreamsAsSpec._
+  import TestScope._
+  import StreamImplicits._
+  implicit val materializer = ActorMaterializer()
+
+  implicit val timeout = 10 seconds
+
+  "Read Event Store" should {
+
+    "get only with supported event" in new TestScope {
+      val scifisBooks = List(SciFiBook(name = "joe"), SciFiBook(name = "brandon"), SciFiBook(name = "steve"), SciFiBook(name = "test"))
+      val godBooks = List(GodBook(name = "Root"))
+
+      val readedEvents = for {
+        _ <- append(streamId = streamId, eventType = SciFiBook.getClass.getSimpleName, jsonData = scifisBooks.map(_.toJson.asJsObject))
+        _ <- append(streamId = streamId, eventType = GodBook.getClass.getSimpleName, jsonData = godBooks.map(_.toJson.asJsObject))
+        events <- connection.getStreamAs[SciFiBook](streamId).read().getOnly.future
+      } yield events.map { case (_, m) => m }
+
+      readedEvents.await_(timeout) should beEqualTo(scifisBooks)
+    }
+
+    "get only with unsupported event" in new TestScope {
+      val members = List(GodBook(name = "joe"), GodBook(name = "brandon"), GodBook(name = "steve"), GodBook(name = "test"))
+      val jsonData = members.map(_.toJson.asJsObject)
+
+      val readedEvents = for {
+        _ <- append(streamId = streamId, eventType = SciFiBook.getClass.getSimpleName, jsonData = jsonData)
+        events <- connection.getStreamAs[GodBook](streamId).read().getOnly.future
+      } yield events.map { case (_, m) => m }.toList
+
+      readedEvents.await_(timeout) should beEmpty
+    }
+
+    "filter with supported event (polymorphism)" in new TestScope {
+      val godBooks = List(GodBook(name = "joe"), GodBook(name = "brandon"), GodBook(name = "steve"), GodBook(name = "test"))
+      val financeBooks: List[FinanceBook] = List(FinanceBook(name = "Root"))
+
+      val readedEvents = for {
+        _ <- append(streamId = streamId, eventType = GodBook.getClass.getSimpleName, jsonData = godBooks.map(_.toJson.asJsObject))
+        _ <- append(streamId = streamId, eventType = FinanceBook.getClass.getSimpleName, jsonData = financeBooks.map(_.toJson.asJsObject))
+        events <- connection.getStreamAs[Book](streamId).read().get.map { case (offset, either) => offset -> either.right.get }.future
+      } yield events.map { case (_, m) => m }.toList
+
+      readedEvents.await_(timeout) should beEqualTo(godBooks ++ financeBooks)
+    }
+
+    "filter with not supported event" in new TestScope {
+      val godBooks = List(GodBook(name = "joe"), GodBook(name = "brandon"), GodBook(name = "steve"), GodBook(name = "test"))
+      val jsonBuddy = JsObject(Map("id" -> JsString(UUID.randomUUID().toString), "buddyName" -> JsString("My Buddy")))
+
+      val readedEvents = for {
+        _ <- append(streamId = streamId, eventType = GodBook.getClass.getSimpleName, jsonData = godBooks.map(_.toJson.asJsObject))
+        _ <- append(streamId = streamId, eventType = "Buddy", jsonData = Seq(jsonBuddy))
+        events <- connection.getStreamAs[Book](streamId).read().getOnly.future
+      } yield events.map { case (_, m) => m }.toList
+
+      readedEvents.await_(timeout) should beEqualTo(godBooks)
+    }
+
+    "read last event on stream not found" in new TestScope {
+      val lastEvent = connection.getStreamAs[Book](streamId).last().getOpt()
+      lastEvent.await_(timeout) should beNone
+    }
+
+    "read first event on stream not found" in new TestScope {
+      val firstEvent = connection.getStreamAs[Book](streamId).first().getOpt()
+      firstEvent.await_(timeout) should beNone
+    }
+
+    "read first event on a new stream" in new TestScope {
+      val book = GodBook(name = "test")
+
+      val readedElement = for {
+        _ <- append(streamId, eventType = GodBook.getClass.getSimpleName, jsonData = book.toJson.asJsObject)
+        firstElement <- connection.getStreamAs[GodBook](streamId).readOne(Offset.First).getOpt()
+      } yield firstElement
+
+      readedElement.await_(timeout) should beSome(book)
+    }
+
+    "read last event on empty stream" in new TestScope {
+      val readedElement = for {
+        _ <- append(streamId, eventType = GodBook.getClass.getSimpleName, jsonData = GodBook(name = "test").toJson.asJsObject)
+        _ <- delete(streamId)
+        lastElement <- connection.getStreamAs[GodBook](streamId).last().getOpt()
+      } yield lastElement
+
+      readedElement.await_(timeout) should beNone
+    }
+
+    "read last optional event not supported on a stream" in new TestScope {
+      val readedElement = for {
+        _ <- append(streamId, eventType = FinanceBook.getClass.getSimpleName, jsonData = FinanceBook(name = "test").toJson.asJsObject)
+        lastElement <- connection.getStreamAs[GodBook](streamId).last().getOpt()
+      } yield lastElement
+
+      readedElement.await_(timeout) should beNone
+    }
+
+    "read last event on a stream" in new TestScope {
+      val book = GodBook(name = "test")
+
+      val readedElement = for {
+        _ <- append(streamId, eventType = GodBook.getClass.getSimpleName, jsonData = book.toJson.asJsObject)
+        lastElement <- connection.getStreamAs[GodBook](streamId).last().getOpt()
+      } yield lastElement
+
+      readedElement.await_(timeout) should beSome(book)
+    }
+
+    "first offset of a new stream" in new TestScope {
+      val readedOffset = for {
+        _ <- append(newStreamId, eventType = GodBook.getClass.getSimpleName, jsonData = GodBook(name = "test").toJson.asJsObject)
+        offset <- connection.getStreamAs[GodBook](streamId).firstOffset().get
+      } yield offset
+
+      readedOffset.map(_.value).await_(timeout) should be_>=(0L)
+    }
+
+    "first offset of a empty Stream" in new TestScope {
+      val readedOffset = for {
+        _ <- delete(streamId)
+        offset <- connection.getStream(streamId).firstOffset().getOptAsLong
+      } yield offset
+
+      readedOffset.await_(timeout) should beNone
+    }
+
+    "last offset of a stream" in new TestScope {
+      val readedOffset = for {
+        _ <- append(streamId, eventType = GodBook.getClass.getSimpleName, jsonData = GodBook(name = "test").toJson.asJsObject)
+        offset <- connection.getStreamAs[GodBook](streamId).lastOffset().get
+      } yield offset
+
+      readedOffset.map(_.value).await_(timeout) should be_>=(1L)
+    }
+
+    "last offset of a empty stream" in new TestScope {
+      val readedOffset = for {
+        _ <- delete(streamId)
+        offset <- connection.getStreamAs[GodBook](streamId).lastOffset().getOptAsLong
+      } yield offset
+
+      readedOffset.await_(timeout) should beNone
+    }
+
+    "last offset as long of a stream not found" in new TestScope {
+      val lastOffset = connection.getStreamAs[GodBook](streamId).lastOffset().getOptAsLong
+      lastOffset.await_(timeout) should beNone
+    }
+
+    "last offset of a stream not found" in new TestScope {
+      val lastOffset = connection.getStreamAs[GodBook](streamId).lastOffset().getOpt
+      lastOffset.await_(timeout) should beNone
+    }
+
+    "last offset of a stream throw failure" in new TestScope {
+      val failure = connection.getStreamAs[GodBook](streamId).lastOffset().get.failed
+      failure.await_(timeout) must haveClass[StreamNotFoundException] //must matchA
+    }
+
+    "last offset as long of a stream throw failure" in new TestScope {
+      val failure = connection.getStreamAs[GodBook](streamId).lastOffset().getAsLong.failed
+      failure.await_(timeout) must haveClass[StreamNotFoundException] //must matchA
+    }
+
+    "last element of a stream" in new TestScope {
+      val book = GodBook(name = "test")
+      val readedElement = for {
+        _ <- append(streamId, eventType = GodBook.getClass.getSimpleName, jsonData = book.toJson.asJsObject)
+        last <- connection.getStreamAs[GodBook](streamId).last().get()
+      } yield last
+
+      readedElement.await_(timeout) should be(book)
+    }
+
+    "first element of a new stream" in new TestScope {
+      val book = GodBook(name = "test")
+
+      val readedElement = for {
+        _ <- append(newStreamId, eventType = GodBook.getClass.getSimpleName, jsonData = book.toJson.asJsObject)
+        first <- connection.getStreamAs[GodBook](streamId).first().get()
+      } yield first
+
+      readedElement.await_(timeout) should be(book)
+    }
+  }
+
+  "Write Event Store" should {
+
+    "read metadata in a empty stream" in new TestScope {
+      val metadata = CustomBookMetadata("Custom metadata")
+
+      val readedMetadata = for {
+        result <- connection.getStreamAs[Book](streamId).readMetadata.asOpt[CustomBookMetadata]
+      } yield result
+
+      readedMetadata.await_(timeout) should beNone
+    }
+
+    "append metadata in a empty stream" in new TestScope {
+      val metadata = CustomBookMetadata("Custom metadata")
+
+      val readedMetadata = for {
+        _ <- connection.getStreamAs[Book](streamId).writeMetadata(metadata)
+        result <- connection.getStreamAs[Book](streamId).readMetadata.as[CustomBookMetadata]
+      } yield result
+
+      readedMetadata.await_(timeout) should beRight(metadata)
+    }
+
+    "last element in a new stream" in new TestScope {
+      val secondBook = GodBook(name = "Second")
+
+      val last = for {
+        _ <- connection.getStreamAs[GodBook](streamId).append(GodBook(name = "First"), secondBook)
+        result <- connection.getStreamAs[GodBook](streamId).last().get()
+      } yield result
+
+      last.await_(timeout) should beEqualTo(secondBook)
+    }
+
+    "append one element with fail on error" in new TestScope {
+      val book = GodBook(name = "joe")
+      val error = connection.getStreamAs[Book](streamId).append(book).failOnError
+
+      error.await_(timeout) should beEqualTo(Done)
+    }
+
+    "append one element" in new TestScope {
+      val append = connection.getStreamAs[Book](streamId).append(GodBook(name = "joe"))
+      append await_ (timeout) should beRight(haveClass[WriteEventsCompleted])
+    }
+
+    "append multiple elements of same type" in new TestScope {
+      val books = List(GodBook(name = "joe"), GodBook(name = "brandon"), GodBook(name = "steve"), GodBook(name = "test"))
+      val append = connection.getStreamAs[GodBook](streamId).appendSeq(books).failOnError
+      append.await_(timeout) should beEqualTo(Done)
+    }
+
+    "append multiple with " in new TestScope {
+      val books = List(GodBook(name = "joe"), SciFiBook(name = "brandon"), FinanceBook(name = "steve"), GodBook(name = "test"))
+
+      val append = connection.getStreamAs[Book](streamId).appendSeq(books).failOnError
+      append.await_(timeout) should beEqualTo(Done)
+    }
+  }
+
+  abstract class TestScope extends TestConnectionScope {
+    val connection = new EsConnection(actor, system)
+
+    def delete(streamId: EventStream.Id): Future[DeleteStreamCompleted] = {
+      connection(DeleteStream(streamId))
+    }
+
+    def append(streamId: EventStream.Id, eventType: String, jsonData: JsObject): Future[WriteEventsCompleted] = {
+      append(streamId, eventType, Seq(jsonData))
+    }
+
+    def append(streamId: EventStream.Id, eventType: String, jsonData: Seq[JsObject]): Future[WriteEventsCompleted] = {
+      val eventData: List[EventData] = jsonData.map(json => EventData(eventType = eventType.replace("$", ""), data = Content.Json(json.toString()))).toList
+
+      val writeCommand = WriteEvents(
+        streamId = streamId,
+        events = eventData
+      )
+
+      connection(writeCommand)
+    }
+  }
+
+  object TestScope {
+    val MaxAllowedSeqSize = 10000
+
+    implicit class PimpedSource[S, T](source: Source[S, T]) {
+      def future(implicit mat: Materializer): Future[immutable.Seq[S]] = future()
+      def future(takeMax: Int = MaxAllowedSeqSize)(implicit mat: Materializer): Future[immutable.Seq[S]] = {
+        source.limit(takeMax.toLong).runWith(Sink.seq)
+      }
+    }
+
+  }
+}

--- a/src/test/scala/eventstore/dsl/EsStreamsITest.scala
+++ b/src/test/scala/eventstore/dsl/EsStreamsITest.scala
@@ -1,0 +1,371 @@
+package eventstore.dsl
+
+import java.util.UUID
+
+import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.scaladsl.{ Sink, Source }
+import eventstore.dsl.supports.SprayJsonFormatsExtension.JavaUUIDFormat
+import eventstore.dsl.supports.{ ADTJsonFormat, SprayJsonEventFormats, SprayJsonMetadataFormats }
+import eventstore.{ EventData, _ }
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+sealed trait User extends Product
+object User {
+  val typesMap = Map(
+    "Admin" -> Admin.adminJsonFormat,
+    "Member" -> Member.memberJsonFormat,
+    "God" -> God.godJsonFormat
+  )
+
+  implicit val JsonFormat = new ADTJsonFormat[User]("type", _.getClass.getSimpleName, typesMap)
+}
+
+case class Member(id: UUID = UUID.randomUUID(), firstName: String, lastName: String = "") extends User
+object Member {
+  implicit val memberJsonFormat = jsonFormat3(Member.apply)
+}
+
+case class Admin(id: UUID = UUID.randomUUID(), firstName: String, lastName: String = "") extends User
+object Admin {
+  implicit val adminJsonFormat = jsonFormat3(Admin.apply)
+}
+
+case class God(id: UUID = UUID.randomUUID(), name: String) extends User
+object God {
+  implicit val godJsonFormat = jsonFormat2(God.apply)
+}
+
+object EsStreamsSpec extends DefaultJsonProtocol {
+  implicit val memberEventFormat = SprayJsonEventFormats.format[Member]
+
+  implicit val adminEventFormat = SprayJsonEventFormats.format[Admin]
+
+  implicit val godEventFormat = SprayJsonEventFormats.format[God]
+
+  implicit val userFormat = SprayJsonEventFormats.adtFormat[User](User.typesMap)
+
+  case class CustomMetadata(text: String)
+
+  implicit val customMetadataJsonFormat = jsonFormat1(CustomMetadata)
+
+  implicit val customMetadataMetaFormat = SprayJsonMetadataFormats.format[CustomMetadata]
+}
+
+class EsStreamsSpec extends TestConnection {
+  implicit val timeout = 10 seconds
+
+  import system.dispatcher
+
+  /*
+  override protected def beforeEach() = {
+    Await.result(delete(streamId), resetTimeout)
+  }
+*/
+
+  /*
+  "Read Event Store" should {
+
+    "only as with supported event" in {
+      val admins = List(Admin(firstName = "joe"), Admin(firstName = "brandon"), Admin(firstName = "steve"), Admin(firstName = "test"))
+      val gods = List(God(name = "Root"))
+
+      val readedEvents = for {
+        _ <- append(streamId = streamId, eventType = Admin.getClass.getSimpleName, jsonData = admins.map(_.toJson.asJsObject))
+        _ <- append(streamId = streamId, eventType = God.getClass.getSimpleName, jsonData = gods.map(_.toJson.asJsObject))
+        events <- connection.getStream(streamId).read().onlyAs[Admin].future
+      } yield events.map { case (_, m) => m }.toList
+
+      readedEvents.futureValue should ===(admins)
+    }
+
+    "only as by unsupported event" in {
+      val members = List(Member(firstName = "joe"), Member(firstName = "brandon"), Member(firstName = "steve"), Member(firstName = "test"))
+      val jsonData = members.map(_.toJson.asJsObject)
+
+      val readedEvents: Future[List[God]] = for {
+        _ <- append(streamId = streamId, eventType = Member.getClass.getSimpleName, jsonData = jsonData)
+        events <- connection.getStream(streamId).read().onlyAs[God].future
+      } yield events.map { case (_, m) => m }.toList
+
+      readedEvents.futureValue shouldBe empty
+    }
+
+    "filter with supported event (polymorphism)" in {
+      val admins: List[User] = List(Admin(firstName = "joe"), Admin(firstName = "brandon"), Admin(firstName = "steve"), Admin(firstName = "test"))
+      val gods: List[User] = List(God(name = "Root"))
+
+      val readedEvents = for {
+        _ <- append(streamId = streamId, eventType = Admin.getClass.getSimpleName, jsonData = admins.map(_.toJson.asJsObject))
+        _ <- append(streamId = streamId, eventType = God.getClass.getSimpleName, jsonData = gods.map(_.toJson.asJsObject))
+        events <- connection.getStream(streamId).read().as[User].map { case (offset, either) => offset -> either.right.get }.future
+      } yield events.map { case (_, m) => m }.toList
+
+      readedEvents.futureValue should ===(admins ++ gods)
+    }
+
+    "filter with not supported event" in {
+      val admins: List[User] = List(Admin(firstName = "joe"), Admin(firstName = "brandon"), Admin(firstName = "steve"), Admin(firstName = "test"))
+      val jsonBuddy = JsObject(Map("id" -> JsString(UUID.randomUUID().toString), "buddyName" -> JsString("My Buddy")))
+
+      val readedEvents = for {
+        _ <- append(streamId = streamId, eventType = Admin.getClass.getSimpleName, jsonData = admins.map(_.toJson.asJsObject))
+        _ <- append(streamId = streamId, eventType = "Buddy", jsonData = Seq(jsonBuddy))
+        events <- connection.getStream(streamId).read().onlyAs[User].future
+      } yield events.map { case (_, m) => m }.toList
+
+      readedEvents.futureValue should ===(admins)
+    }
+
+    "read last event on stream not found" in {
+      val randomStreamId = EventStream.Id(UUID.randomUUID().toString)
+
+      val readedEvent = connection.getStream(randomStreamId).last().asOpt[Member]
+
+      readedEvent.futureValue should ===(None)
+    }
+
+    "read first event on stream not found" in {
+      val randomStreamId = EventStream.Id(UUID.randomUUID().toString)
+
+      val readedEvent = connection.getStream(randomStreamId).first().asOpt[Member]
+
+      readedEvent.futureValue should ===(None)
+    }
+
+    "read first event on a new stream" in {
+      val newStreamID = EventStream.Id(UUID.randomUUID().toString)
+      val admin = Admin(firstName = "test")
+
+      val readedElement = for {
+        _ <- append(newStreamID, eventType = Admin.getClass.getSimpleName, jsonData = admin.toJson.asJsObject)
+        firstElement <- connection.getStream(newStreamID).readOne(Offset.First).asOpt[Admin]
+      } yield firstElement
+
+      readedElement.futureValue should ===(Some(admin))
+
+    }
+
+    "read last event on empty stream" in {
+      val admin = Admin(firstName = "test")
+
+      val readedElement = for {
+        _ <- append(streamId, eventType = Admin.getClass.getSimpleName, jsonData = admin.toJson.asJsObject)
+        _ <- delete(streamId)
+        lastElement <- connection.getStream(streamId).last().asOpt[Member]
+      } yield lastElement
+
+      readedElement.futureValue should ===(None)
+    }
+
+    "read last optional event not supported on a stream" in {
+      val readedElement = for {
+        _ <- append(streamId, eventType = Admin.getClass.getSimpleName, jsonData = Admin(firstName = "test").toJson.asJsObject)
+        lastElement <- connection.getStream(streamId).last().asOpt[Member]
+      } yield lastElement
+
+      readedElement.futureValue should ===(None)
+    }
+
+    "read last event on a stream" in {
+      val admin = Admin(firstName = "test")
+      val readedElement = for {
+        _ <- append(streamId, eventType = Admin.getClass.getSimpleName, jsonData = admin.toJson.asJsObject)
+        lastElement <- connection.getStream(streamId).last().asOpt[Admin]
+      } yield lastElement
+
+      readedElement.futureValue should ===(Some(admin))
+    }
+
+    "first offset of a new stream" in {
+      val newStreamId = EventStream.Id(UUID.randomUUID().toString)
+
+      val readedOffset = for {
+        _ <- append(newStreamId, eventType = Admin.getClass.getSimpleName, jsonData = Admin(firstName = "test").toJson.asJsObject)
+        offset <- connection.getStream(newStreamId).firstOffset().get
+      } yield offset
+
+      readedOffset.futureValue.value should be >= 0L
+    }
+
+    "first offset of a empty Stream" in {
+      val readedOffset = for {
+        _ <- delete(streamId)
+        offset <- connection.getStream(streamId).firstOffset().getOptAsLong
+      } yield offset
+
+      readedOffset.futureValue should ===(None)
+    }
+
+    "last offset of a stream" in {
+      val readedOffset = for {
+        _ <- append(streamId, eventType = Admin.getClass.getSimpleName, jsonData = Admin(firstName = "test").toJson.asJsObject)
+        offset <- connection.getStream(streamId).lastOffset().get
+      } yield offset
+
+      readedOffset.futureValue.value should be >= 1L
+    }
+
+    "last offset of a empty stream" in {
+      val readedOffset = for {
+        _ <- delete(streamId)
+        offset <- connection.getStream(streamId).lastOffset().getOptAsLong
+      } yield offset
+
+      readedOffset.futureValue should ===(None)
+    }
+
+    "last element of a stream" in {
+      val admin = Admin(firstName = "test")
+      val readedElement = for {
+        _ <- append(streamId, eventType = Admin.getClass.getSimpleName, jsonData = admin.toJson.asJsObject)
+        last <- connection.getStream(streamId).last().as[Admin]
+      } yield last
+
+      readedElement.futureValue should ===(admin)
+    }
+
+    "first element of a new stream" in {
+      val newStreamId = EventStream.Id(UUID.randomUUID().toString)
+      val admin = Admin(firstName = "test")
+
+      val readedElement = for {
+        _ <- append(newStreamId, eventType = Admin.getClass.getSimpleName, jsonData = admin.toJson.asJsObject)
+        first <- connection.getStream(newStreamId).first().as[Admin]
+      } yield first
+
+      readedElement.futureValue should ===(admin)
+    }
+
+    "read to a deleted stream  with new elements" in {
+      val newStreamId = EventStream.Id(UUID.randomUUID().toString)
+
+      val stream = connection.getStream(newStreamId)
+
+      val admin1 = Admin(firstName = "test1")
+      val admin2 = Admin(firstName = "test2")
+
+      val readedElements = for {
+        _ <- stream.append(admin1, admin2)
+        _ <- stream.delete()
+        _ <- stream.append(admin1, admin2)
+        readEvents <- stream.read().onlyAs[Admin].future
+      } yield readEvents.map { case (_, m) => m }
+
+      readedElements.futureValue should ===(Seq(admin1, admin2))
+    }
+
+    "fetch last element on a deleted stream" in {
+      val newStreamId = EventStream.Id(UUID.randomUUID().toString)
+
+      val stream = connection.getStream(newStreamId)
+
+      val admin1 = Admin(firstName = "test1")
+      val admin2 = Admin(firstName = "test2")
+
+      val readedElement = for {
+        _ <- stream.append(admin1, admin2)
+        _ <- stream.delete()
+        last <- stream.last().asOpt[Admin]
+
+      } yield last
+
+      readedElement.futureValue should ===(None)
+    }
+
+    "fetch last offset on a deleted stream" in {
+      val newStreamId = EventStream.Id(UUID.randomUUID().toString)
+
+      val stream = connection.getStream(newStreamId)
+
+      val admin1 = Admin(firstName = "test1")
+      val admin2 = Admin(firstName = "test2")
+
+      val readedElement = for {
+        _ <- stream.append(admin1, admin2)
+        _ <- stream.delete()
+        last <- stream.lastOffset().getOpt
+
+      } yield last
+
+      readedElement.futureValue should ===(None)
+    }
+
+  }
+
+
+  "Write Event Store" should {
+
+    "append metadata in a empty stream" in {
+      val metadata = CustomMetadata("Custom metadata")
+      val newStreamId = EventStream.Id(UUID.randomUUID().toString)
+
+      val readedMetadata = for {
+        _ <- connection.getStream(newStreamId).writeMetadata(metadata)
+        metadata <- connection.getStream(newStreamId).readMetadata.asOpt[CustomMetadata]
+      } yield metadata
+
+      readedMetadata.futureValue should ===(Some(metadata))
+    }
+
+    "append event in a new stream" in {
+      val newStreamId = EventStream.Id(UUID.randomUUID().toString)
+      val secondAdmin = Admin(firstName = "Second")
+
+      val last = for {
+        _ <- connection.getStream(newStreamId).append(Admin(firstName = "First"), secondAdmin)
+        lastValue <- connection.getStream(newStreamId).last().as[Admin]
+      } yield lastValue
+
+      last.futureValue should ===(secondAdmin)
+    }
+
+    //    "append one event on not empty stream" in {}
+    //    "append one event on an empty stream" in {}
+    //    "append one event of a stream not found" in {}
+
+  }
+*/
+
+  abstract class TestScope extends TestConnectionScope {
+    val connection = new EsConnection(actor, system)
+    implicit val materializer = ActorMaterializer()
+
+    def delete(streamId: EventStream.Id): Future[DeleteStreamCompleted] = {
+      connection(DeleteStream(streamId))
+    }
+
+    def append(streamId: EventStream.Id, eventType: String, jsonData: JsObject): Future[WriteEventsCompleted] = {
+      append(streamId, eventType, Seq(jsonData))
+    }
+
+    def append(streamId: EventStream.Id, eventType: String, jsonData: Seq[JsObject]): Future[WriteEventsCompleted] = {
+      val eventData: List[EventData] = jsonData.map(json => EventData(eventType = eventType.replace("$", ""), data = Content.Json(json.toString()))).toList
+
+      val writeCommand = WriteEvents(
+        streamId = streamId,
+        events = eventData
+      )
+
+      connection(writeCommand)
+    }
+  }
+
+  object TestScope {
+
+    val MaxAllowedSeqSize = 10000
+
+    implicit class PimpedSource[S, T](source: Source[S, T]) {
+      def future(implicit mat: Materializer): Future[immutable.Seq[S]] = future()
+      def future(takeMax: Int = MaxAllowedSeqSize)(implicit mat: Materializer): Future[immutable.Seq[S]] = {
+        source.limit(takeMax.toLong).runWith(Sink.seq)
+      }
+    }
+
+  }
+
+}

--- a/src/test/scala/eventstore/dsl/TestDslScope.scala
+++ b/src/test/scala/eventstore/dsl/TestDslScope.scala
@@ -1,0 +1,10 @@
+package eventstore.dsl
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Sink, Source }
+import eventstore.{ Content, DeleteStream, DeleteStreamCompleted, EsConnection, EventData, EventStream, WriteEvents, WriteEventsCompleted }
+import spray.json.JsObject
+
+import scala.collection.immutable
+import scala.concurrent.Future
+


### PR DESCRIPTION
Here a proposal to have a nice dsl and to deal with stream with Akka Stream.

```scala
case class SciFiBook(id: UUID = UUID.randomUUID(), name: String, author: String = "")

import EsConnectionExtension._

implicit val JsonFormat = jsonFormat3(SciFiBook) //provide a JsonFormat
implicit val sciFiBookEventFormat = SprayJsonEventFormats.format[SciFiBook] //provide an eventFormat

val stream = connection.getStream("myStream")

stream.append(SciFiBook(name ="test-book"))
```

```scala
trait ReadStream {
  def subscribe(startOffset: Offset = Offset.First): ReadAll
  def read(startOffset: Offset = Offset.First, infinite: Boolean = false): ReadAll
  def readOne(offset: Offset)(implicit ec: ExecutionContext): ReadOne 
  def last()(implicit ec: ExecutionContext): ReadOne
  def first()(implicit ec: ExecutionContext): ReadOne
  def firstOffset()(implicit ec: ExecutionContext): ReadOffset
  def lastOffset()(implicit ec: ExecutionContext): ReadOffset
}

trait WriteStreamAs[T] extends BaseWriteStream {
  protected[this] implicit val eventWriter: EventWriter[T]

  def append(events: T*): Future[Either[WriteStreamError, WriteEventsCompleted]] 
  def appendSeq(events: Seq[T]): Future[Either[WriteStreamError, WriteEventsCompleted]]
  def appendAt(offset: Offset, events: T*): Future[Either[WriteStreamError, WriteEventsCompleted]] 
  def appendSeqAt(offset: Offset, events: Seq[T]): Future[Either[WriteStreamError, WriteEventsCompleted]] 
}
```

What do you think. i still need to fix my integration test... What do you think ???

