### PR TITLE
streams: graph stage

### DIFF
--- a/src/main/java/eventstore/j/EsConnection.java
+++ b/src/main/java/eventstore/j/EsConnection.java
@@ -1,5 +1,7 @@
 package eventstore.j;
 
+import akka.NotUsed;
+import akka.stream.javadsl.Source;
 import eventstore.*;
 import org.reactivestreams.Publisher;
 import scala.concurrent.Future;
@@ -479,6 +481,30 @@ public interface EsConnection {
       UserCredentials credentials,
       boolean infinite);
 
+  /**
+   * Creates a Source you can use to subscribe to a single event stream. Existing events from
+   * event number onwards are read from the stream and presented to the user of
+   * <code>Source</code> as if they had been pushed.
+   * <p>
+   * Once the end of the stream is read the <code>Source</code> transparently (to the user)
+   * switches to push new events as they are written.
+   * <p>
+   * If events have already been received and resubscription from the same point
+   * is desired, use the event number of the last event processed.
+   *
+   * @param stream                   The stream to subscribe to
+   * @param fromEventNumberExclusive The event number from which to start, or <code>null</code> to read all events.
+   * @param resolveLinkTos           Whether to resolve LinkTo events automatically
+   * @param credentials              The optional user credentials to perform operation with
+   * @param infinite                 Whether to subscribe to the future events upon reading all current
+   * @return A {@link akka.stream.javadsl.Source} representing the stream
+   */
+   Source<Event, NotUsed> streamSource(
+      String stream,
+      EventNumber fromEventNumberExclusive,
+      boolean resolveLinkTos,
+      UserCredentials credentials,
+      boolean infinite);
 
   /**
    * Creates Publisher you can use to subscribes to a all events. Existing events from position
@@ -500,6 +526,29 @@ public interface EsConnection {
    * @return A {@link org.reactivestreams.Publisher} representing all streams
    */
   Publisher<IndexedEvent> allStreamsPublisher(
+      Position fromPositionExclusive,
+      boolean resolveLinkTos,
+      UserCredentials credentials,
+      boolean infinite);
+
+  /**
+   * Creates a Source you can use to subscribes to all events. Existing events from position
+   * onwards are read from the Event Store and presented to the user of
+   * <code>Source</code> as if they had been pushed.
+   * <p>
+   * Once the end of the stream is read the <code>Source</code> transparently (to the user)
+   * switches to push new events as they are written.
+   * <p>
+   * If events have already been received and resubscription from the same point
+   * is desired, use the position representing the last event processed.
+   *
+   * @param fromPositionExclusive The position from which to start, or <code>null</code> to read all events
+   * @param resolveLinkTos        Whether to resolve LinkTo events automatically
+   * @param credentials           The optional user credentials to perform operation with
+   * @param infinite              Whether to subscribe to the future events upon reading all current
+   * @return A {@link akka.stream.javadsl.Source} representing all streams
+   */
+  Source<IndexedEvent, NotUsed> allStreamsSource(
       Position fromPositionExclusive,
       boolean resolveLinkTos,
       UserCredentials credentials,

--- a/src/main/scala/eventstore/AllStreamsSourceStage.scala
+++ b/src/main/scala/eventstore/AllStreamsSourceStage.scala
@@ -1,0 +1,53 @@
+package eventstore
+
+import akka.actor.ActorRef
+import akka.actor.Actor.Receive
+import akka.stream._
+import akka.stream.stage._
+import akka.stream.{ Attributes, SourceShape }
+import eventstore.ReadDirection.Forward
+import Position._
+import EventStream._
+
+private[eventstore] class AllStreamsSourceStage(
+    connection:            ActorRef,
+    fromPositionExclusive: Option[Position],
+    credentials:           Option[UserCredentials],
+    settings:              Settings,
+    infinite:              Boolean                 = true
+) extends GraphStage[SourceShape[IndexedEvent]] {
+
+  val out: Outlet[IndexedEvent] = Outlet("AllStreamsSource")
+  val shape: SourceShape[IndexedEvent] = SourceShape(out)
+
+  def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new SourceStageLogic[IndexedEvent, Position, Exact](
+      shape, out, All, connection, credentials, settings, infinite
+    ) {
+
+      import settings._
+
+      final val first: Exact = First
+      final val eventFrom: IndexedEvent ⇒ IndexedEvent = identity
+      final val positionFrom: IndexedEvent ⇒ Exact = _.position
+      final val pointerFrom: Exact ⇒ Long = _.commitPosition
+
+      final def positionExclusive: Option[StreamPointer] = fromPositionExclusive map {
+        case Last     ⇒ StreamPointer.Last
+        case e: Exact ⇒ StreamPointer.Exact(e)
+      }
+
+      final def buildReadEventsFrom(next: Exact): Out = ReadAllEvents(
+        next, readBatchSize, Forward, resolveLinkTos, requireMaster
+      )
+
+      final def rcvRead(next: Exact, onRead: (List[IndexedEvent], Exact, Boolean) ⇒ Unit): Receive = {
+        case ReadAllEventsCompleted(events, _, n, Forward) ⇒ onRead(events, n, events.isEmpty)
+      }
+
+      final def rcvSubscribed(onSubscribed: Option[Exact] ⇒ Unit): Receive = {
+        case SubscribeToAllCompleted(x) ⇒ onSubscribed(Some(Position.Exact(x)))
+      }
+
+    }
+}

--- a/src/main/scala/eventstore/SourceStageLogic.scala
+++ b/src/main/scala/eventstore/SourceStageLogic.scala
@@ -1,0 +1,237 @@
+package eventstore
+
+import scala.collection._
+import scala.collection.immutable.Queue
+import akka.actor.ActorRef
+import akka.actor.Actor.Receive
+import akka.actor.Terminated
+import akka.actor.Status.Failure
+import akka.stream._
+import akka.stream.stage._
+import akka.stream.stage.GraphStageLogic.StageActor
+import akka.stream.SourceShape
+
+private[eventstore] abstract class SourceStageLogic[T, O <: Ordered[O], P <: O](
+    shape:       SourceShape[T],
+    out:         Outlet[T],
+    streamId:    EventStream,
+    connection:  ActorRef,
+    credentials: Option[UserCredentials],
+    settings:    Settings,
+    infinite:    Boolean
+) extends GraphStageLogic(shape) with StageLogging {
+
+  def first: P
+  def eventFrom: IndexedEvent ⇒ T
+  def positionFrom: T ⇒ P
+  def pointerFrom: P ⇒ Long
+  def positionExclusive: Option[StreamPointer]
+
+  ///
+
+  private var last: Option[P] = positionExclusive collect { case StreamPointer.Exact(p) ⇒ p }
+  private val buffer = mutable.Queue.empty[T]
+  private val emptyBehavior = PartialFunction.empty
+  private def ready = buffer.size <= settings.readBatchSize
+
+  ///
+
+  override def preStart(): Unit = {
+
+    super.preStart()
+
+    become(emptyBehavior).watch(connection)
+
+    positionExclusive match {
+      case Some(StreamPointer.Last)     ⇒ become(subscribingFromLast)
+      case Some(StreamPointer.Exact(p)) ⇒ become(reading(p))
+      case None                         ⇒ become(reading(first))
+    }
+
+  }
+
+  def reading(next: P): Receive = {
+
+    def read(events: List[T], next: P, endOfStream: Boolean): Unit = become {
+      enqueueAndPush(events: _*)
+      if (endOfStream) {
+        if (infinite) subscribing(next)
+        else drainAndComplete()
+      } else if (ready) reading(next)
+      else rcvRequest(reading(next))
+    }
+
+    readEventsFrom(next)
+    rcvRead(next, read) or rcvRequest()
+  }
+
+  def subscribingFromLast: Receive = {
+    if (infinite) {
+      subscribeToStream()
+      rcvSubscribed(_ ⇒ become(subscribed)) or rcvUnsubscribed or rcvRequest()
+    } else {
+      completeStage()
+      emptyBehavior
+    }
+  }
+
+  def subscribing(next: P): Receive = {
+
+    def subscribed(subscriptionNumber: Option[P]): Unit = become {
+      subscriptionNumber
+        .filter(sn ⇒ last.forall(l ⇒ pointerFrom(sn) > pointerFrom(l)))
+        .map(sn ⇒ catchingUp(next, sn, Queue()))
+        .getOrElse(this.subscribed)
+    }
+
+    subscribeToStream()
+    rcvSubscribed(subscribed) or rcvUnsubscribed or rcvRequest()
+  }
+
+  def unsubscribing: Receive = {
+
+    def unsubscribed = {
+      def reading = this.reading(last getOrElse first)
+      if (ready) reading
+      else rcvRequest(reading)
+    }
+
+    unsubscribe()
+    rcvUnsubscribed(unsubscribed) or rcvRequest()
+  }
+
+  def subscribed: Receive = {
+
+    def eventAppeared(event: IndexedEvent) = {
+      enqueueAndPush(eventFrom(event))
+      if (ready) subscribed else unsubscribing
+    }
+
+    rcvEventAppeared(eventAppeared) or
+      rcvUnsubscribed or
+      rcvRequest()
+  }
+
+  def catchingUp(next: P, subscriptionNumber: P, stash: Queue[T]): Receive = {
+
+    def catchUp(subscriptionNumber: P, stash: Queue[T]): Receive = {
+
+      val subPos = pointerFrom(subscriptionNumber)
+      val evtPos = positionFrom andThen pointerFrom
+
+      def read(es: List[T], next: P, eos: Boolean): Unit = become {
+        enqueueAndPush(es: _*)
+        if (es.isEmpty || es.exists(evtPos(_) > subPos)) {
+          enqueueAndPush(stash: _*)
+          subscribed
+        } else {
+          if (ready)
+            catchingUp(next, subscriptionNumber, stash)
+          else unsubscribing
+        }
+      }
+
+      def eventAppeared(event: IndexedEvent) =
+        catchUp(subscriptionNumber, stash enqueue eventFrom(event))
+
+      rcvRead(next, read) or
+        rcvEventAppeared(eventAppeared) or
+        rcvUnsubscribed or
+        rcvRequest()
+    }
+
+    readEventsFrom(next)
+    catchUp(subscriptionNumber, stash)
+  }
+
+  def drainAndComplete(): Receive = {
+    emitMultiple(out, buffer.iterator, () ⇒ completeStage())
+    emptyBehavior
+  }
+
+  /// State related
+
+  def enqueueAndPush(events: T*): Unit = {
+
+    def enqueue(event: T): Unit = {
+      val lastIn = buffer.lastOption.map(positionFrom).orElse(last)
+      if (lastIn.forall(_ < positionFrom(event))) buffer.enqueue(event)
+    }
+
+    events.foreach(enqueue)
+    push()
+  }
+
+  def push(): Unit = if (isAvailable(out) && buffer.nonEmpty) {
+    val event = buffer.dequeue()
+    last = Some(positionFrom(event))
+    push(out, event)
+  }
+
+  /// StageActor Related
+
+  private def become(receive: Receive): StageActor = getStageActor {
+    case (_, m) if receive.isDefinedAt(m) ⇒ receive(m)
+    case (_, Terminated(`connection`))    ⇒ completeStage()
+    case (_, Failure(failure))            ⇒ failStage(failure)
+    case (r, m)                           ⇒ log.warning(s"unhandled from message $r: $m")
+  }
+
+  /// Messages from OutHandler
+
+  def rcvRequest(): Receive = {
+    case Pump ⇒ push()
+  }
+
+  def rcvRequest(receive: ⇒ Receive): Receive = {
+    case Pump ⇒ push(); if (ready) become(receive)
+  }
+
+  /// Messages from Connection
+
+  def rcvRead(next: P, onRead: (List[T], P, Boolean) ⇒ Unit): Receive
+  def rcvSubscribed(receive: Option[P] ⇒ Unit): Receive
+
+  def rcvUnsubscribed(receive: ⇒ Receive): Receive = {
+    case Unsubscribed ⇒ become(receive)
+  }
+
+  def rcvUnsubscribed(): Receive = {
+    case Unsubscribed ⇒ completeStage()
+  }
+
+  def rcvEventAppeared(receive: IndexedEvent ⇒ Receive): Receive = {
+    case StreamEventAppeared(x) ⇒ become(receive(x))
+  }
+
+  /// Messages to Connection
+
+  def buildReadEventsFrom(p: P): Out
+
+  def readEventsFrom(next: P): Unit = {
+    toConnection(buildReadEventsFrom(next))
+  }
+
+  def toConnection(x: Out) =
+    connection.tell(credentials.fold[OutLike](x)(x.withCredentials), stageActor.ref)
+
+  def subscribeToStream() =
+    toConnection(SubscribeTo(streamId, resolveLinkTos = settings.resolveLinkTos))
+
+  def unsubscribe() = toConnection(Unsubscribe)
+
+  ///
+
+  setHandler(out, new OutHandler {
+    def onPull(): Unit = stageActor.ref ! Pump
+  })
+
+  case object Pump
+
+  sealed trait StreamPointer extends Product with Serializable
+  object StreamPointer {
+    case object Last extends StreamPointer
+    case class Exact(p: P) extends StreamPointer
+  }
+
+}

--- a/src/main/scala/eventstore/StreamSourceStage.scala
+++ b/src/main/scala/eventstore/StreamSourceStage.scala
@@ -1,0 +1,54 @@
+package eventstore
+
+import akka.actor.ActorRef
+import akka.actor.Actor.Receive
+import akka.actor.Status.Failure
+import akka.stream._
+import akka.stream.stage._
+import akka.stream.{ Attributes, SourceShape }
+import eventstore.ReadDirection.Forward
+import EventNumber._
+
+private[eventstore] class StreamSourceStage(
+    connection:          ActorRef,
+    streamId:            EventStream.Id,
+    fromNumberExclusive: Option[EventNumber],
+    credentials:         Option[UserCredentials],
+    settings:            Settings,
+    infinite:            Boolean                 = true
+) extends GraphStage[SourceShape[Event]] {
+
+  val out: Outlet[Event] = Outlet("StreamSource")
+  val shape: SourceShape[Event] = SourceShape(out)
+
+  def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new SourceStageLogic[Event, EventNumber, Exact](
+      shape, out, streamId, connection, credentials, settings, infinite
+    ) {
+
+      import settings._
+
+      final val first: Exact = First
+      final val eventFrom: IndexedEvent ⇒ Event = _.event
+      final val pointerFrom: Exact ⇒ Long = _.value
+      final val positionFrom: Event ⇒ Exact = _.number
+
+      final def positionExclusive: Option[StreamPointer] = fromNumberExclusive map {
+        case Last     ⇒ StreamPointer.Last
+        case e: Exact ⇒ StreamPointer.Exact(e)
+      }
+
+      final def buildReadEventsFrom(next: Exact): Out = ReadStreamEvents(
+        streamId, next, readBatchSize, Forward, resolveLinkTos, requireMaster
+      )
+
+      final def rcvRead(next: Exact, onRead: (List[Event], Exact, Boolean) ⇒ Unit): Receive = {
+        case ReadStreamEventsCompleted(e, n: Exact, _, eos, _, Forward) ⇒ onRead(e, n, eos)
+        case Failure(_: StreamNotFoundException)                        ⇒ onRead(Nil, next, true)
+      }
+
+      final def rcvSubscribed(onSubscribed: Option[Exact] ⇒ Unit): Receive = {
+        case SubscribeToStreamCompleted(_, subscriptionNumber) ⇒ onSubscribed(subscriptionNumber)
+      }
+    }
+}

--- a/src/main/scala/eventstore/j/EsConnectionImpl.scala
+++ b/src/main/scala/eventstore/j/EsConnectionImpl.scala
@@ -2,8 +2,9 @@ package eventstore
 package j
 
 import java.util
-
+import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.stream.javadsl.Source
 import eventstore.ExpectedVersion.Existing
 
 import scala.collection.JavaConverters._
@@ -323,6 +324,24 @@ class EsConnectionImpl(
     )
   }
 
+  def streamSource(
+    stream:                   String,
+    fromEventNumberExclusive: EventNumber,
+    resolveLinkTos:           Boolean,
+    credentials:              UserCredentials,
+    infinite:                 Boolean
+  ): Source[Event, NotUsed] = {
+
+    connection.streamSource(
+      streamId = EventStream.Id(stream),
+      fromEventNumberExclusive = Option(fromEventNumberExclusive),
+      resolveLinkTos = resolveLinkTos,
+      credentials = Option(credentials),
+      infinite = infinite
+    ).asJava
+
+  }
+
   def allStreamsPublisher(
     fromPositionExclusive: Position,
     resolveLinkTos:        Boolean,
@@ -336,6 +355,22 @@ class EsConnectionImpl(
       credentials = Option(credentials),
       infinite = infinite
     )
+  }
+
+  def allStreamsSource(
+    fromPositionExclusive: Position,
+    resolveLinkTos:        Boolean,
+    credentials:           UserCredentials,
+    infinite:              Boolean
+  ): Source[IndexedEvent, NotUsed] = {
+
+    connection.allStreamsSource(
+      resolveLinkTos = resolveLinkTos,
+      fromPositionExclusive = Option(fromPositionExclusive),
+      credentials = Option(credentials),
+      infinite = infinite
+    ).asJava
+
   }
 
   def createPersistentSubscription(

--- a/src/test/scala/eventstore/AllStreamsSourceITest.scala
+++ b/src/test/scala/eventstore/AllStreamsSourceITest.scala
@@ -1,0 +1,122 @@
+package eventstore
+
+import akka.stream.ActorMaterializer
+import akka.stream.testkit.scaladsl.TestSink
+import scala.concurrent.duration._
+
+class AllStreamsSourceITest extends TestConnection {
+  implicit val materializer = ActorMaterializer()
+
+  "AllStreamsSource" should {
+
+    "subscribe to all" in new Scope {
+
+      val src = sourceFiltered().map(_.event.data)
+
+      val events1 = appendMany(size = 3, sid = streamIdA)
+      val events2 = appendMany(size = 3, sid = streamIdB)
+      val events3 = appendMany(size = 3, sid = streamIdC)
+      val events4 = appendMany(size = 3, sid = streamIdA)
+      val events = events1 ++ events2 ++ events3 ++ events4
+
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+    }
+
+    "subscribe from number" in new Scope {
+
+      appendMany(20)
+
+      val events = source()
+        .runWith(TestSink.probe[IndexedEvent])
+        .request(10)
+        .expectNextN(10)
+
+      source(Some(events.head.position))
+        .runWith(TestSink.probe[IndexedEvent])
+        .request(9)
+        .expectNextN(events drop 1)
+
+    }
+
+    "subscribe from last" in new Scope {
+      appendMany(20)
+
+      val probe = sourceFiltered(Some(Position.Last)).map(_.event.data)
+        .runWith(TestSink.probe[EventData])
+
+      probe.request(1).expectNoMessage(300.millis)
+
+      val events = appendMany(2)
+
+      probe.request(events.size.toLong).expectNextN(events)
+
+    }
+
+  }
+
+  "AllStreamsSource finite" should {
+
+    "subscribe to all" in new Scope {
+
+      val events = appendMany(3, sid = streamIdB)
+
+      val src = sourceFiltered(infinite = false).map { _.event.data }
+
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+        .request(1)
+        .expectComplete()
+    }
+
+    "subscribe from number" in new Scope {
+
+      appendMany()
+
+      val events = sourceFiltered()
+        .runWith(TestSink.probe[IndexedEvent])
+        .request(10)
+        .expectNextN(10)
+
+      sourceFiltered(Some(events.head.position), infinite = false)
+        .runWith(TestSink.probe[IndexedEvent])
+        .request(9)
+        .expectNextN(events drop 1)
+        .request(1)
+        .expectComplete()
+
+    }
+
+    "subscribe from last" in new Scope {
+
+      appendMany()
+
+      sourceFiltered(Some(Position.Last), infinite = false)
+        .map(_.event.data)
+        .runWith(TestSink.probe[EventData])
+        .request(1)
+        .expectComplete()
+
+    }
+
+  }
+
+  private trait Scope extends TestConnectionScope {
+    val connection = new EsConnection(actor, system)
+
+    private val streamIdPrefix = s"${streamId.value}"
+
+    val streamIdA = EventStream.Plain(streamIdPrefix + "_a")
+    val streamIdB = EventStream.Plain(streamIdPrefix + "_b")
+    val streamIdC = EventStream.Plain(streamIdPrefix + "_c")
+
+    def sourceFiltered(position: Option[Position] = None, infinite: Boolean = true, resolveLinkTos: Boolean = false) =
+      source(position, infinite, resolveLinkTos).filter(_.event.streamId.value.startsWith(streamIdPrefix))
+
+    def source(position: Option[Position] = None, infinite: Boolean = true, resolveLinkTos: Boolean = false) = {
+      connection.allStreamsSource(resolveLinkTos, position, infinite = infinite, readBatchSize = 10)
+    }
+  }
+}

--- a/src/test/scala/eventstore/AllStreamsSourceSpec.scala
+++ b/src/test/scala/eventstore/AllStreamsSourceSpec.scala
@@ -1,0 +1,391 @@
+package eventstore
+
+import akka.NotUsed
+import akka.actor.Status.Failure
+import akka.stream.scaladsl._
+import eventstore.ReadDirection.Forward
+import eventstore.util.SourceSpec
+
+class AllStreamsSourceSpec extends SourceSpec {
+
+  "AllStreamsSource" should {
+
+    "read events from given position" in new SourceScope {
+      connection expectMsg readEvents(123)
+
+      override def position = Some(Position(123))
+    }
+
+    "read events from start if no position given" in new SourceScope {
+      connection expectMsg readEvents(0)
+    }
+
+    "subscribe if last position given" in new SourceScope {
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(0)
+      connection.expectNoMessage(duration)
+      connection reply StreamEventAppeared(event1)
+      connection reply StreamEventAppeared(event0)
+      connection reply StreamEventAppeared(event2)
+      expectEvent(event1)
+      expectEvent(event2)
+
+      override def position = Some(Position.Last)
+    }
+
+    "ignore read events with position out of interest" in new SourceScope {
+      connection expectMsg readEvents(0)
+
+      connection reply readCompleted(0, 3, event0, event1, event2)
+      expectEvent(event0)
+      expectEvent(event1)
+      expectEvent(event2)
+
+      connection expectMsg readEvents(3)
+
+      connection reply readCompleted(3, 5, event0, event1, event2, event3, event4)
+
+      expectEvent(event3)
+      expectEvent(event4)
+
+      connection expectMsg readEvents(5)
+
+      connection reply readCompleted(3, 5, event0, event1, event2, event3, event4)
+
+      expectNoEvent()
+      connection expectMsg readEvents(5)
+    }
+
+    "ignore read events with position out of interest when start position is given" in new SourceScope {
+      connection expectMsg readEvents(1)
+
+      connection reply readCompleted(0, 3, event0, event1, event2)
+      expectEvent(event2)
+      expectNoEvent()
+
+      connection expectMsg readEvents(3)
+
+      override def position = Some(Position(1))
+    }
+
+    "read events until none left and subscribe to new ones" in new SourceScope {
+      connection expectMsg readEvents(0)
+      val nextPosition = 2L
+      connection reply readCompleted(1, nextPosition, event1)
+
+      expectEvent(event1)
+
+      connection expectMsg readEvents(nextPosition)
+      connection reply readCompleted(nextPosition, nextPosition)
+
+      connection.expectMsg(subscribeTo)
+    }
+
+    "subscribe to new events if nothing to read" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+      connection.expectMsg(subscribeTo)
+
+      connection reply subscribeCompleted(1)
+
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+    }
+
+    "catch events that appear in between reading and subscribing" in new SourceScope {
+      connection expectMsg readEvents(0)
+
+      connection reply readCompleted(0, 2, event0, event1)
+
+      expectEvent(event0)
+      expectEvent(event1)
+
+      connection expectMsg readEvents(2)
+      connection reply readCompleted(2, 2)
+
+      expectNoEvent()
+      connection.expectMsg(subscribeTo)
+
+      connection reply subscribeCompleted(4)
+
+      connection expectMsg readEvents(2)
+
+      connection reply StreamEventAppeared(event2)
+      connection reply StreamEventAppeared(event3)
+      connection reply StreamEventAppeared(event4)
+      expectNoEvent()
+
+      connection reply readCompleted(2, 3, event1, event2)
+      expectEvent(event2)
+
+      connection expectMsg readEvents(3)
+
+      connection reply StreamEventAppeared(event5)
+      connection reply StreamEventAppeared(event6)
+      expectNoEvent()
+
+      connection reply readCompleted(3, 6, event3, event4, event5)
+
+      expectEvent(event3)
+      expectEvent(event4)
+      expectEvent(event5)
+      expectEvent(event6)
+
+      connection reply StreamEventAppeared(event5)
+      connection reply StreamEventAppeared(event6)
+
+      expectNoActivity()
+    }
+
+    "continue with subscription if no events appear in between reading and subscribing" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+
+      connection.expectMsg(subscribeTo)
+      expectNoEvent()
+
+      connection reply subscribeCompleted(1)
+
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+
+      expectNoActivity()
+    }
+
+    "continue with subscription if no events appear in between reading and subscribing and position is given" in
+      new SourceScope {
+        connection expectMsg readEvents(1)
+
+        connection reply readCompleted(1, 1)
+
+        connection.expectMsg(subscribeTo)
+        expectNoEvent()
+
+        connection reply subscribeCompleted(1)
+
+        expectNoActivity()
+
+        override def position = Some(Position(1))
+      }
+
+    "forward events while subscribed" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+
+      connection.expectMsg(subscribeTo)
+      expectNoEvent()
+
+      connection reply subscribeCompleted(1)
+
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+
+      connection reply StreamEventAppeared(event1)
+      expectEvent(event1)
+
+      expectNoEvent()
+      //      expectNoMsg(duration)
+
+      connection reply StreamEventAppeared(event2)
+      connection reply StreamEventAppeared(event3)
+      expectEvent(event2)
+      expectEvent(event3)
+    }
+
+    "ignore wrong events while subscribed" in new SourceScope {
+      connection expectMsg readEvents(1)
+      connection reply readCompleted(1, 1)
+
+      connection.expectMsg(subscribeTo)
+      connection reply subscribeCompleted(2)
+
+      connection expectMsg readEvents(1)
+      connection reply readCompleted(1, 1)
+
+      connection reply StreamEventAppeared(event0)
+      connection reply StreamEventAppeared(event1)
+      connection reply StreamEventAppeared(event1)
+      connection reply StreamEventAppeared(event2)
+      expectEvent(event2)
+      connection reply StreamEventAppeared(event2)
+      connection reply StreamEventAppeared(event1)
+      connection reply StreamEventAppeared(event3)
+      expectEvent(event3)
+      connection reply StreamEventAppeared(event5)
+      expectEvent(event5)
+      connection reply StreamEventAppeared(event4)
+      expectNoEvent()
+
+      override def position = Some(Position(1))
+    }
+
+    "stop source if connection stopped" in new SourceScope {
+      connection expectMsg readEvents(0)
+      system stop connection.ref
+      expectComplete()
+    }
+
+    "stop source if error while reading" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply Failure(failure)
+
+      expectError(failure)
+      expectNoActivity()
+    }
+
+    "stop source if error while subscribing" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+      connection expectMsg subscribeTo
+
+      connection reply Failure(failure)
+
+      expectError(failure)
+      expectNoActivity()
+
+      override def position = Some(Position(0))
+    }
+
+    "stop source if error while catching up" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(0)
+
+      connection expectMsg readEvents(0)
+      connection reply Failure(failure)
+
+      expectError(failure)
+      expectNoActivity()
+    }
+
+    "stop source if error while live processing" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(0)
+
+      connection reply Failure(failure)
+
+      expectError(failure)
+      expectNoActivity()
+
+      override def position = Some(Position(0))
+    }
+
+    "resubscribe from same position" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(0)
+      connection reply subscribeCompleted(0)
+      expectNoActivity()
+
+      override def position = Some(Position(0))
+    }
+
+    "resubscribe from different position" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(1)
+      connection expectMsg readEvents(0)
+      connection reply StreamEventAppeared(event1)
+      connection reply StreamEventAppeared(event2)
+      connection reply readCompleted(0, 3, event0, event1, event2)
+      expectEvent(event1)
+      expectEvent(event2)
+
+      override def position = Some(Position(0))
+    }
+
+    "ignore resubscribed while catching up" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(0)
+      connection expectMsg readEvents(0)
+      connection reply StreamEventAppeared(event1)
+      connection reply StreamEventAppeared(event2)
+      connection reply StreamEventAppeared(event3)
+      connection reply subscribeCompleted(1)
+      connection reply StreamEventAppeared(event1)
+      connection reply StreamEventAppeared(event2)
+      connection reply StreamEventAppeared(event3)
+      connection reply readCompleted(0, 3, event0, event1, event2)
+
+      expectEvent(event0)
+      expectEvent(event1)
+      expectEvent(event2)
+    }
+
+    "use credentials if given" in new SourceScope {
+      connection expectMsg readEvents(0).withCredentials(credentials.get)
+      connection reply readCompleted(0, 0)
+      connection expectMsg subscribeTo.withCredentials(credentials.get)
+
+      override def credentials = Some(UserCredentials("login", "password"))
+    }
+
+  }
+
+  "AllStreamsSource finite" should {
+
+    "stop immediately if last position passed" in new FiniteSubscriptionScope {
+      connection.expectNoMessage(duration)
+      expectComplete()
+
+      override def position = Some(Position.Last)
+    }
+
+    "stop when no more events left" in new FiniteSubscriptionScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 0)
+      expectComplete()
+    }
+
+    "stop when retrieved last event" in new FiniteSubscriptionScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, 2, event0, event1)
+      expectEvent(event0)
+      expectEvent(event1)
+      connection expectMsg readEvents(2)
+      connection reply readCompleted(2, 2)
+      expectComplete()
+    }
+
+  }
+
+  private trait SourceScope extends AbstractSourceScope[IndexedEvent] {
+
+    lazy val streamId = EventStream.All
+    def position: Option[Position] = None
+
+    def createSource(): Source[IndexedEvent, NotUsed] =
+      Source.fromGraph(new AllStreamsSourceStage(
+        connection.ref,
+        position,
+        credentials,
+        Settings.Default.copy(readBatchSize = readBatchSize, resolveLinkTos = resolveLinkTos),
+        infinite
+      ))
+
+    ///
+
+    def newEvent(x: Long) =
+      IndexedEvent(mock[Event], Position.Exact(x))
+
+    def readEvents(x: Long) =
+      ReadAllEvents(Position(x), readBatchSize, Forward, resolveLinkTos = resolveLinkTos)
+
+    def readCompleted(position: Long, next: Long, events: IndexedEvent*) =
+      ReadAllEventsCompleted(events.toList, Position.Exact(position), Position.Exact(next), Forward)
+
+    def subscribeCompleted(lastCommit: Long) = SubscribeToAllCompleted(lastCommit)
+
+  }
+
+  private trait FiniteSubscriptionScope extends SourceScope {
+    override def infinite = false
+  }
+}

--- a/src/test/scala/eventstore/StreamSourceITest.scala
+++ b/src/test/scala/eventstore/StreamSourceITest.scala
@@ -1,0 +1,197 @@
+package eventstore
+
+import akka.stream.ActorMaterializer
+import akka.stream.testkit.scaladsl.TestSink
+import scala.concurrent.duration._
+
+class StreamSourceITest extends TestConnection {
+  implicit val materializer = ActorMaterializer()
+
+  "StreamSource" should {
+    "subscribe to stream" in new Scope {
+      val events = appendMany(3)
+      val src = source().map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+    }
+
+    "subscribe to stream from number" in new Scope {
+      val events = appendMany(3) drop 1
+      val src = source(Some(EventNumber.First)).map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+    }
+
+    "subscribe to non-existing stream" in new Scope {
+      val src = source().map { _.data }
+      val probe = src.runWith(TestSink.probe[EventData])
+      val events = appendMany(3)
+      probe.request(events.size.toLong)
+        .expectNextN(events)
+    }
+
+    "subscribe to non-existing stream from number" in new Scope {
+      val src = source(Some(EventNumber.First)).map { _.data }
+      val probe = src.runWith(TestSink.probe[EventData])
+      val events = appendMany(3).drop(1)
+      probe.request(events.size.toLong)
+        .expectNextN(events)
+    }
+
+    "subscribe to soft deleted stream" in new Scope {
+      appendEventToCreateStream()
+      deleteStream(hard = false)
+      val events = appendMany(size = 2)
+      val src = source(Some(EventNumber.First)) map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+    }
+
+    "subscribe to soft deleted long stream" in new Scope {
+      appendEventToCreateStream()
+      appendMany(size = 20)
+      deleteStream(hard = false)
+      val events = appendMany(size = 2)
+      val src = source(Some(EventNumber.First)) map { _.data }
+
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+    }
+
+    "subscribe to soft deleted empty stream" in new Scope {
+      appendEventToCreateStream()
+      deleteStream(hard = false)
+      val src = source(Some(EventNumber.First)) map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(1)
+        .expectNoMessage(300.millis)
+    }
+
+    "subscribe to truncated stream" in new Scope {
+      appendEventToCreateStream()
+      truncateStream(EventNumber.Exact(1))
+      val events = appendMany(size = 2)
+      val src = source(Some(EventNumber.First)) map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+    }
+
+    "subscribe to truncated long stream" in new Scope {
+      appendEventToCreateStream()
+      appendMany(size = 20)
+      truncateStream(EventNumber.Exact(21))
+      val events = appendMany(size = 2)
+      val src = source(Some(EventNumber.First)) map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+    }
+  }
+
+  "StreamSource finite" should {
+    "subscribe to stream" in new Scope {
+      val events = appendMany(3)
+      val src = source(infinite = false).map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+        .expectComplete()
+    }
+
+    "subscribe to stream from number" in new Scope {
+      val events = appendMany(3) drop 1
+      val src = source(Some(EventNumber.First), infinite = false).map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+        .expectComplete()
+    }
+
+    "subscribe to non-existing stream" in new Scope {
+      val src = source(infinite = false).map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(1)
+        .expectComplete()
+    }
+
+    "subscribe to non-existing stream from number" in new Scope {
+      val src = source(Some(EventNumber.First), infinite = false).map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(1)
+        .expectComplete()
+    }
+
+    "subscribe to soft deleted stream" in new Scope {
+      appendEventToCreateStream()
+      deleteStream(hard = false)
+      val events = appendMany(size = 2)
+      val src = source(Some(EventNumber.First), infinite = false) map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+        .request(1)
+        .expectComplete()
+    }
+
+    "subscribe to soft deleted long stream" in new Scope {
+      appendEventToCreateStream()
+      appendMany(size = 20)
+      deleteStream(hard = false)
+      val events = appendMany(size = 2)
+      val src = source(Some(EventNumber.First), infinite = false) map { _.data }
+
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+        .request(1)
+        .expectComplete()
+    }
+
+    "subscribe to soft deleted empty stream" in new Scope {
+      appendEventToCreateStream()
+      deleteStream(hard = false)
+      val src = source(Some(EventNumber.First), infinite = false) map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(1)
+        .expectComplete()
+    }
+
+    "subscribe to truncated stream" in new Scope {
+      appendEventToCreateStream()
+      truncateStream(EventNumber.Exact(1))
+      val events = appendMany(size = 2)
+      val src = source(Some(EventNumber.First), infinite = false) map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+        .request(1)
+        .expectComplete()
+    }
+
+    "subscribe to truncated long stream" in new Scope {
+      appendEventToCreateStream()
+      appendMany(size = 20)
+      truncateStream(EventNumber.Exact(21))
+      val events = appendMany(size = 2)
+      val src = source(Some(EventNumber.First), infinite = false) map { _.data }
+      src.runWith(TestSink.probe[EventData])
+        .request(events.size.toLong)
+        .expectNextN(events)
+        .request(1)
+        .expectComplete()
+    }
+  }
+
+  private trait Scope extends TestConnectionScope {
+    val connection = new EsConnection(actor, system)
+
+    def source(eventNumber: Option[EventNumber] = None, infinite: Boolean = true) = {
+      connection.streamSource(streamId, eventNumber, infinite = infinite, readBatchSize = 10)
+    }
+  }
+}

--- a/src/test/scala/eventstore/StreamSourceSpec.scala
+++ b/src/test/scala/eventstore/StreamSourceSpec.scala
@@ -1,0 +1,430 @@
+package eventstore
+
+import akka.NotUsed
+import akka.actor.Status
+import akka.actor.Status.Failure
+import akka.stream.scaladsl._
+import eventstore.ReadDirection.Forward
+import eventstore.util.SourceSpec
+
+class StreamSourceSpec extends SourceSpec {
+
+  "StreamSource" should {
+
+    "read events from given position" in new SourceScope {
+      connection expectMsg readEvents(123)
+
+      override def eventNumber = Some(EventNumber(123))
+    }
+
+    "read events from start if no position given" in new SourceScope {
+      connection expectMsg readEvents(0)
+    }
+
+    "subscribe if last position given" in new SourceScope {
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(0)
+      connection.expectNoMessage()
+      connection reply streamEventAppeared(event1)
+      connection reply streamEventAppeared(event0)
+      connection reply streamEventAppeared(event2)
+      expectEvent(event1)
+      expectEvent(event2)
+
+      override def eventNumber = Some(EventNumber.Last)
+    }
+
+    "ignore read events with event number out of interest" in new SourceScope {
+      connection expectMsg readEvents(0)
+
+      connection reply readCompleted(3, false, event0, event1, event2)
+      expectEvent(event0)
+      expectEvent(event1)
+      expectEvent(event2)
+
+      connection expectMsg readEvents(3)
+
+      connection reply readCompleted(5, false, event0, event1, event2, event3, event4)
+
+      expectEvent(event3)
+      expectEvent(event4)
+
+      connection expectMsg readEvents(5)
+
+      connection reply readCompleted(5, false, event0, event1, event2, event3, event4)
+
+      expectNoEvent()
+      connection expectMsg readEvents(5)
+    }
+
+    "ignore read events with event number out of interest when from number is given" in new SourceScope {
+      connection expectMsg readEvents(1)
+
+      connection reply readCompleted(3, false, event0, event1, event2)
+      expectEvent(event2)
+      expectNoEvent()
+
+      connection expectMsg readEvents(3)
+
+      override def eventNumber = Some(EventNumber(1))
+    }
+
+    "read events until none left and subscribe to new ones" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(2, false, event1)
+
+      expectEvent(event1)
+
+      connection expectMsg readEvents(2)
+      connection reply readCompleted(2, endOfStream = true)
+
+      connection expectMsg subscribeTo
+    }
+
+    "subscribe to new events if nothing to read" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, endOfStream = true)
+      connection expectMsg subscribeTo
+
+      connection reply subscribeCompleted(1)
+
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, endOfStream = true)
+    }
+
+    "catch events that appear in between reading and subscribing" in new SourceScope {
+      connection expectMsg readEvents(0)
+
+      connection reply readCompleted(2, false, event0, event1)
+
+      expectEvent(event0)
+      expectEvent(event1)
+
+      connection expectMsg readEvents(2)
+      connection reply readCompleted(2, endOfStream = true)
+
+      expectNoEvent()
+      connection expectMsg subscribeTo
+
+      connection reply subscribeCompleted(4)
+
+      connection expectMsg readEvents(2)
+
+      connection reply streamEventAppeared(event2)
+      connection reply streamEventAppeared(event3)
+      connection reply streamEventAppeared(event4)
+      expectNoEvent()
+
+      connection reply readCompleted(3, false, event1, event2)
+      expectEvent(event2)
+
+      connection expectMsg readEvents(3)
+
+      connection reply streamEventAppeared(event5)
+      connection reply streamEventAppeared(event6)
+      expectNoEvent()
+
+      connection reply readCompleted(6, false, event3, event4, event5)
+
+      expectEvent(event3)
+      expectEvent(event4)
+      expectEvent(event5)
+      expectEvent(event6)
+
+      connection reply streamEventAppeared(event5)
+      connection reply streamEventAppeared(event6)
+
+      expectNoActivity()
+    }
+
+    "continue with subscription if no events appear in between reading and subscribing" in new SourceScope {
+      val position = 0L
+      connection expectMsg readEvents(position)
+      connection reply readCompleted(position, endOfStream = true)
+
+      connection expectMsg subscribeTo
+      expectNoEvent()
+
+      connection reply subscribeCompleted(1)
+
+      connection expectMsg readEvents(position)
+      connection reply readCompleted(position, endOfStream = true)
+
+      expectNoActivity()
+    }
+
+    "continue with subscription if no events appear in between reading and subscribing and position is given" in
+      new SourceScope {
+        val position = 1L
+        connection expectMsg readEvents(position)
+
+        connection reply readCompleted(position, endOfStream = true)
+
+        connection expectMsg subscribeTo
+        expectNoEvent()
+
+        connection reply subscribeCompleted(1)
+
+        expectNoActivity()
+
+        override def eventNumber = Some(EventNumber(1))
+      }
+
+    "forward events while subscribed" in new SourceScope {
+      val position = 0L
+      connection expectMsg readEvents(position)
+      connection reply readCompleted(position, endOfStream = true)
+
+      connection expectMsg subscribeTo
+      expectNoEvent()
+
+      connection reply subscribeCompleted(1)
+
+      connection expectMsg readEvents(position)
+      connection reply readCompleted(position, endOfStream = true)
+
+      connection reply streamEventAppeared(event1)
+      expectEvent(event1)
+
+      expectNoEvent()
+
+      connection reply streamEventAppeared(event2)
+      connection reply streamEventAppeared(event3)
+      expectEvent(event2)
+      expectEvent(event3)
+    }
+
+    "ignore wrong events while subscribed" in new SourceScope {
+      connection expectMsg readEvents(1)
+      connection reply readCompleted(1, endOfStream = true)
+
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(2)
+
+      connection expectMsg readEvents(1)
+      connection reply readCompleted(1, endOfStream = true)
+
+      connection reply streamEventAppeared(event0)
+      connection reply streamEventAppeared(event1)
+      connection reply streamEventAppeared(event1)
+      connection reply streamEventAppeared(event2)
+      expectEvent(event2)
+      connection reply streamEventAppeared(event2)
+      connection reply streamEventAppeared(event1)
+      connection reply streamEventAppeared(event3)
+      expectEvent(event3)
+      connection reply streamEventAppeared(event5)
+      expectEvent(event5)
+      connection reply streamEventAppeared(event4)
+      expectNoEvent()
+
+      override def eventNumber = Some(EventNumber(1))
+    }
+
+    "complete source if connection stopped" in new SourceScope {
+      connection expectMsg readEvents(0)
+      system stop connection.ref
+      expectComplete()
+    }
+
+    "stop source if error while reading" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply Failure(failure)
+
+      expectError(failure)
+      expectNoActivity()
+    }
+
+    "stop source if error while subscribing" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, endOfStream = true)
+      connection expectMsg subscribeTo
+      connection reply Failure(failure)
+
+      expectError(failure)
+      expectNoActivity()
+
+      override def eventNumber = Some(EventNumber(0))
+    }
+
+    "stop source if error while catching up" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, endOfStream = true)
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(0)
+      connection reply Failure(failure)
+
+      expectError(failure)
+      expectNoActivity()
+
+      override def eventNumber = Some(EventNumber(0))
+    }
+
+    "stop source if error while live processing" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, endOfStream = true)
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(0)
+      connection reply Failure(failure)
+
+      expectError(failure)
+      expectNoActivity()
+
+      override def eventNumber = Some(EventNumber(0))
+    }
+
+    "resubscribe from same position" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, endOfStream = true)
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(0)
+      expectNoActivity()
+
+      override def eventNumber = Some(EventNumber(0))
+    }
+
+    "resubscribe from different position" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, endOfStream = true)
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(1)
+      connection reply streamEventAppeared(event1)
+      connection reply streamEventAppeared(event2)
+      connection reply readCompleted(3, false, event0, event1, event2)
+      expectEvent(event1)
+      expectEvent(event2)
+
+      override def eventNumber = Some(EventNumber(0))
+    }
+
+    "ignore resubscribe while catching up" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, endOfStream = true)
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(1)
+      connection expectMsg readEvents(0)
+      connection reply streamEventAppeared(event0)
+      connection reply streamEventAppeared(event1)
+      connection reply streamEventAppeared(event2)
+      connection reply streamEventAppeared(event3)
+      connection reply subscribeCompleted(2)
+      connection reply streamEventAppeared(event1)
+      connection reply streamEventAppeared(event2)
+      connection reply streamEventAppeared(event3)
+      connection reply readCompleted(0, true, event0, event1, event2)
+
+      expectEvent(event1)
+      expectEvent(event2)
+      expectEvent(event3)
+
+      override def eventNumber = Some(EventNumber(0))
+    }
+
+    "use credentials if given" in new SourceScope {
+      connection expectMsg readEvents(0).withCredentials(credentials.get)
+      connection reply readCompleted(0, endOfStream = true)
+      connection expectMsg subscribeTo.withCredentials(credentials.get)
+
+      override def credentials = Some(UserCredentials("login", "password"))
+    }
+
+    "subscribe to non-existing stream" in new SourceScope {
+      connection expectMsg readEvents(0)
+      connection reply Status.Failure(StreamNotFoundException(streamId))
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(0)
+      connection expectMsg readEvents(0)
+    }
+
+    "subscribe to non-existing stream if last number passed" in new SourceScope {
+      connection expectMsg readEvents(2)
+      connection reply Status.Failure(StreamNotFoundException(streamId))
+      connection expectMsg subscribeTo
+      connection reply subscribeCompleted(2)
+      connection reply streamEventAppeared(event3)
+      expectEvent(event3)
+
+      override def eventNumber = Some(EventNumber.Exact(2))
+    }
+
+  }
+
+  "StreamSource finite" should {
+
+    "stop immediately if last number passed" in new FiniteSourceScope {
+      connection.expectNoMessage()
+      expectComplete()
+
+      override def eventNumber = Some(EventNumber.Last)
+    }
+
+    "stop when no more events left" in new FiniteSourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(0, endOfStream = true)
+      expectComplete()
+    }
+
+    "stop when retrieved last event" in new FiniteSourceScope {
+      connection expectMsg readEvents(0)
+      connection reply readCompleted(2, false, event0, event1)
+      expectEvent(event0)
+      expectEvent(event1)
+      connection expectMsg readEvents(2)
+      connection reply readCompleted(2, endOfStream = true)
+      expectComplete()
+    }
+
+    "subscribe to non-existing stream" in new FiniteSourceScope {
+      connection expectMsg readEvents(0)
+      connection reply Status.Failure(StreamNotFoundException(streamId))
+      expectComplete()
+    }
+
+    "subscribe to non-existing stream if last number passed" in new FiniteSourceScope {
+      connection expectMsg readEvents(5)
+      connection reply Status.Failure(StreamNotFoundException(streamId))
+      expectComplete()
+
+      override def eventNumber = Some(EventNumber.Exact(5))
+    }
+  }
+
+  private trait SourceScope extends AbstractSourceScope[Event] {
+
+    lazy val streamId = EventStream.Id(StreamSourceSpec.this.getClass.getSimpleName + "-" + randomUuid.toString)
+    def eventNumber: Option[EventNumber] = None
+
+    def createSource(): Source[Event, NotUsed] =
+      Source.fromGraph(new StreamSourceStage(
+        connection.ref,
+        streamId,
+        eventNumber,
+        credentials,
+        Settings.Default.copy(readBatchSize = readBatchSize, resolveLinkTos = resolveLinkTos),
+        infinite
+      ))
+
+    def newEvent(number: Long): Event =
+      EventRecord(streamId, EventNumber.Exact(number), mock[EventData])
+
+    def readEvents(x: Long) =
+      ReadStreamEvents(streamId, EventNumber(x), readBatchSize, Forward, resolveLinkTos = resolveLinkTos)
+
+    def readCompleted(next: Long, endOfStream: Boolean, events: Event*) = ReadStreamEventsCompleted(
+      events = events.toList,
+      nextEventNumber = EventNumber(next),
+      lastEventNumber = mock[EventNumber.Exact],
+      endOfStream = endOfStream,
+      lastCommitPosition = next.toLong,
+      direction = Forward
+    )
+
+    def subscribeCompleted(x: Long) = SubscribeToStreamCompleted(x.toLong, Some(EventNumber.Exact(x)))
+    def streamEventAppeared(x: Event) = StreamEventAppeared(IndexedEvent(x, Position.Exact(x.number.value)))
+
+  }
+
+  private trait FiniteSourceScope extends SourceScope {
+    override def infinite = false
+  }
+}

--- a/src/test/scala/eventstore/TestConnection.scala
+++ b/src/test/scala/eventstore/TestConnection.scala
@@ -60,8 +60,8 @@ abstract class TestConnection extends util.ActorSpec {
       event
     }
 
-    def append(x: EventData): EventRecord = {
-      EventRecord(streamId, writeEventsCompleted(List(x), testKit = TestProbe()).get.start, x, Some(date))
+    def append(x: EventData, sid: EventStream.Id = streamId): EventRecord = {
+      EventRecord(sid, writeEventsCompleted(List(x), testKit = TestProbe()).get.start, x, Some(date))
     }
 
     def linkedAndLink(): (EventRecord, EventRecord) = {
@@ -71,9 +71,9 @@ abstract class TestConnection extends util.ActorSpec {
       (linked, link)
     }
 
-    def appendMany(size: Int = 10, testKit: TestKitBase = this): List[EventData] = {
+    def appendMany(size: Int = 10, testKit: TestKitBase = this, sid: EventStream.Id = streamId): List[EventData] = {
       val events = (1 to size).map(_ => newEventData).toList
-      actor.!(WriteEvents(streamId, events, ExpectedVersion.Any))(testKit.testActor)
+      actor.!(WriteEvents(sid, events, ExpectedVersion.Any))(testKit.testActor)
       testKit.expectMsgType[WriteEventsCompleted]
       events
     }

--- a/src/test/scala/eventstore/j/EsConnectionITest.scala
+++ b/src/test/scala/eventstore/j/EsConnectionITest.scala
@@ -183,6 +183,29 @@ class EsConnectionITest extends eventstore.util.ActorSpec {
 
       probe.expectNextN(3)
     }
+
+    "publish stream events (source)" in new TestScope {
+      val streamId = s"java-source-stream-$randomUuid"
+      val source = connection.streamSource(streamId, null, false, null, false)
+      await_(connection.writeEvents(streamId, null, events, null))
+      source
+        .map(_.data)
+        .runWith(TestSink.probe[EventData], materializer)
+        .request(1)
+        .expectNext(eventData)
+        .expectComplete()
+    }
+
+    "publish all streams (source)" in new TestScope {
+      val streamId = s"java-source-stream-$randomUuid"
+      val source = connection.allStreamsSource(Position.First, false, null, true)
+      await_(connection.writeEvents(streamId, null, eventsM, null))
+      source
+        .runWith(TestSink.probe[IndexedEvent], materializer)
+        .request(15)
+        .expectNextN(10)
+    }
+
   }
 
   private trait TestScope extends ActorScope {
@@ -190,6 +213,7 @@ class EsConnectionITest extends eventstore.util.ActorSpec {
     val connection: EsConnection = new EsConnectionImpl(eventstore.EsConnection(system), Settings.Default, system.dispatcher)
     val eventData = newEventData
     val events = List(eventData).asJava
+    val eventsM = List.fill(20)(newEventData).asJava
 
     def eventType = "java-test"
     def newEventData = EventData(eventType = eventType, data = Content("data"), metadata = Content("metadata"))

--- a/src/test/scala/eventstore/util/SourceSpec.scala
+++ b/src/test/scala/eventstore/util/SourceSpec.scala
@@ -1,0 +1,65 @@
+package eventstore
+package util
+
+import akka.NotUsed
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl._
+import akka.stream.testkit.scaladsl._
+import akka.testkit._
+import org.specs2.mock.Mockito
+import scala.concurrent.duration._
+
+abstract class SourceSpec extends util.ActorSpec with Mockito {
+
+  abstract class AbstractSourceScope[T] extends ActorScope {
+
+    implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+    val duration = 1.second
+    val readBatchSize = 2
+    val resolveLinkTos = false
+    val connection = TestProbe()
+    def streamId: EventStream
+
+    val probe = createSource()
+      .runWith(TestSink.probe[T])
+      .ensureSubscription()
+
+    def createSource(): Source[T, NotUsed]
+    def newEvent(x: Long): T
+
+    val event0 = newEvent(0)
+    val event1 = newEvent(1)
+    val event2 = newEvent(2)
+    val event3 = newEvent(3)
+    val event4 = newEvent(4)
+    val event5 = newEvent(5)
+    val event6 = newEvent(6)
+    val failure = new ServerErrorException("test")
+
+    ///
+
+    def expectError(t: Throwable): Unit =
+      probe.expectError(t)
+
+    def expectNoActivity(): Unit = {
+      expectNoEvent()
+      connection.expectNoMessage(duration)
+    }
+
+    def expectNoEvent(): Unit =
+      probe.request(1).expectNoMessage(duration)
+
+    def expectComplete(): Unit =
+      probe.request(1).expectComplete()
+
+    def expectEvent(x: T): Unit =
+      probe.requestNext(x)
+
+    def subscribeTo = SubscribeTo(streamId, resolveLinkTos = resolveLinkTos)
+    def credentials: Option[UserCredentials] = None
+    def infinite = true
+
+  }
+
+}


### PR DESCRIPTION
 - add `StreamSource` and `AllStreamsSource` graph stages
   that replace deprecated `ActorPublisher` implementations
   `StreamPublisher` and `AllStreamsPublisher`.

Closes #99

Co-authored-by: bardurdam <bardurdam@gmail.com>