### PR TITLE
extension: make connection lazy

### DIFF
--- a/src/main/scala/eventstore/EventStoreExtension.scala
+++ b/src/main/scala/eventstore/EventStoreExtension.scala
@@ -7,16 +7,14 @@ class EventStoreExtension(system: ActorSystem) extends Extension {
 
   def settings: Settings = Settings(system.settings.config)
 
-  val actor: ActorRef = system.actorOf(ConnectionActor.props(settings), "eventstore-connection")
-
-  val connection: EsConnection = new EsConnection(actor, system, settings)
-
+  lazy val actor: ActorRef = system.actorOf(ConnectionActor.props(settings), "eventstore-connection")
+  lazy val connection: EsConnection = new EsConnection(actor, system, settings)
   lazy val projectionsClient: ProjectionsClient = new ProjectionsClient(settings, system)
 
   /**
    * Java API
    */
-  val connectionJava: j.EsConnection = j.EsConnectionImpl(system, settings)
+  lazy val connectionJava: j.EsConnection = j.EsConnectionImpl(system, settings)
 }
 
 object EventStoreExtension extends ExtensionId[EventStoreExtension] with ExtensionIdProvider {


### PR DESCRIPTION
 - make extension lazy in order to avoid having two
   instances of `ConnectionActor` running.