### PR TITLE
streams: fix source stage wrt. event number

### DIFF
--- a/src/main/scala/eventstore/StreamSourceStage.scala
+++ b/src/main/scala/eventstore/StreamSourceStage.scala
@@ -31,7 +31,7 @@ private[eventstore] class StreamSourceStage(
       final val first: Exact = First
       final val eventFrom: IndexedEvent ⇒ Event = _.event
       final val pointerFrom: Exact ⇒ Long = _.value
-      final val positionFrom: Event ⇒ Exact = _.number
+      final val positionFrom: Event ⇒ Exact = _.record.number
 
       final def positionExclusive: Option[StreamPointer] = fromNumberExclusive map {
         case Last     ⇒ StreamPointer.Last

--- a/src/test/scala/eventstore/StreamSourceSpec.scala
+++ b/src/test/scala/eventstore/StreamSourceSpec.scala
@@ -21,6 +21,23 @@ class StreamSourceSpec extends SourceSpec {
       connection expectMsg readEvents(0)
     }
 
+    "read events record event number" in new SourceScope {
+
+      connection expectMsg readEvents(0)
+
+      val e1 = EventRecord(EventStream.Id("e-a1"), EventNumber.First, EventData("a"))
+      val r1 = ResolvedEvent(e1.record, EventRecord(streamId, EventNumber.First, e1.link()))
+
+      val e2 = EventRecord(EventStream.Id("e-b1"), EventNumber.First, EventData("b"))
+      val r2 = ResolvedEvent(e2.record, EventRecord(streamId, EventNumber.Exact(1), e2.link()))
+
+      connection reply readCompleted(2, false, r1, r2)
+
+      expectEvent(r1)
+      expectEvent(r2)
+
+    }
+
     "subscribe if last position given" in new SourceScope {
       connection expectMsg subscribeTo
       connection reply subscribeCompleted(0)


### PR DESCRIPTION
- change `StreamSourceStage` to use `event.record.number` such that event
  numbers are correctly for resolved events.