### PR TITLE
fix StreamSubscriptionActor when being resubscribed while catching up

### DIFF
--- a/src/main/scala/eventstore/StreamSubscriptionActor.scala
+++ b/src/main/scala/eventstore/StreamSubscriptionActor.scala
@@ -163,7 +163,7 @@ class StreamSubscriptionActor private (
       }
 
       def subscribed(number: Last) = {
-        catchUp(subscriptionNumber, Queue())
+        catchUp(number.getOrElse(subscriptionNumber), Queue())
       }
 
       rcvEventAppeared(eventAppeared) or


### PR DESCRIPTION
- update catchup-to eventnumber when being resubscribed by ES while
  catching up

- add test that proves fix

- this issue is not present in `SubscriptionActor`