### PR TITLE
refactor SourceStageLogic such that it is easier to reason about

### DIFF
--- a/src/main/scala/eventstore/StreamSourceStage.scala
+++ b/src/main/scala/eventstore/StreamSourceStage.scala
@@ -33,22 +33,24 @@ private[eventstore] class StreamSourceStage(
       final val pointerFrom: Exact ⇒ Long = _.value
       final val positionFrom: Event ⇒ Exact = _.record.number
 
-      final def positionExclusive: Option[StreamPointer] = fromNumberExclusive map {
-        case Last     ⇒ StreamPointer.Last
-        case e: Exact ⇒ StreamPointer.Exact(e)
+      final def operation: ReadFrom = fromNumberExclusive match {
+        case Some(Last)     ⇒ ReadFrom.End
+        case Some(e: Exact) ⇒ ReadFrom.Exact(e)
+        case None           ⇒ ReadFrom.Beginning
       }
 
       final def buildReadEventsFrom(next: Exact): Out = ReadStreamEvents(
         streamId, next, readBatchSize, Forward, resolveLinkTos, requireMaster
       )
 
-      final def rcvRead(next: Exact, onRead: (List[Event], Exact, Boolean) ⇒ Unit): Receive = {
+      final def rcvRead(onRead: (List[Event], Exact, Boolean) => Unit, onNotExists: => Unit): Receive = {
         case ReadStreamEventsCompleted(e, n: Exact, _, eos, _, Forward) ⇒ onRead(e, n, eos)
-        case Failure(_: StreamNotFoundException)                        ⇒ onRead(Nil, next, true)
+        case Failure(_: StreamNotFoundException)                        ⇒ onNotExists
       }
 
       final def rcvSubscribed(onSubscribed: Option[Exact] ⇒ Unit): Receive = {
         case SubscribeToStreamCompleted(_, subscriptionNumber) ⇒ onSubscribed(subscriptionNumber)
       }
+
     }
 }

--- a/src/test/scala/eventstore/AllStreamsSourceSpec.scala
+++ b/src/test/scala/eventstore/AllStreamsSourceSpec.scala
@@ -108,14 +108,14 @@ class AllStreamsSourceSpec extends SourceSpec {
 
       connection reply subscribeCompleted(4)
 
-      connection expectMsg readEvents(2)
+      connection expectMsg readEvents(1)
 
       connection reply StreamEventAppeared(event2)
       connection reply StreamEventAppeared(event3)
       connection reply StreamEventAppeared(event4)
       expectNoEvent()
 
-      connection reply readCompleted(2, 3, event1, event2)
+      connection reply readCompleted(1, 3, event1, event2)
       expectEvent(event2)
 
       connection expectMsg readEvents(3)
@@ -320,8 +320,6 @@ class AllStreamsSourceSpec extends SourceSpec {
       val testEvent1 = newEvent(1337)
       val testEvent2 = newEvent(1338)
 
-      connection expectMsg subscribeTo
-      connection reply Unsubscribed
       connection expectMsg subscribeTo
       connection reply subscribeCompleted(1336)
       connection.expectNoMessage()


### PR DESCRIPTION
refactor `SourceStageLogic`s internal implementation such that it is easier to reason about.

- the implementation does not keep track of next position in order to simplify implementation. This means that the last read event may be read again in some cases, but in turn, fewer events are re-read overall because it keeps track of the last enqueued event instead of the last pushed event

improve test coverage for:
- unexpected resubscriptions during catching up and subscribed
- temporarily unsubscribing when buffer is full
- pausing reading when buffer is full