### PR TITLE
misc: change stagelogic logging of errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ after_success:
 jobs:
   include:
     - stage: integration
-      scala: 2.12.6
+      scala: 2.12.8
       env: AKKA_TEST_TIMEFACTOR=1.5 AKKA_TEST_LOGLEVEL=OFF
       before_install:
-        - docker pull eventstore/eventstore
-        - docker run -d --rm --name eventstore-node -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=1200 eventstore/eventstore
+        - docker pull eventstore/eventstore:release-4.1.2
+        - docker run -d --rm --name eventstore-node -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=1200 eventstore/eventstore:release-4.1.2
       script:
         - sbt test:compile
         - travis_retry sbt it:test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </tr>
   <tr>
     <td><a href="http://akka.io">Akka</a> </td>
-    <td>2.5.19</td>
+    <td>2.5.21</td>
   </tr>
   <tr>
     <td><a href="https://eventstore.org">Event Store</a></td>
@@ -54,7 +54,7 @@ connection ! ReadEvent(EventStream.Id("my-stream"), EventNumber.First)
 
 #### Sbt
 ```scala
-libraryDependencies += "com.geteventstore" %% "eventstore-client" % "5.0.9"
+libraryDependencies += "com.geteventstore" %% "eventstore-client" % "5.0.10"
 ```
 
 #### Maven
@@ -62,7 +62,7 @@ libraryDependencies += "com.geteventstore" %% "eventstore-client" % "5.0.9"
 <dependency>
     <groupId>com.geteventstore</groupId>
     <artifactId>eventstore-client_${scala.version}</artifactId>
-    <version>5.0.9</version>
+    <version>5.0.10</version>
 </dependency>
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -38,8 +38,8 @@ scalacOptions in(Compile, doc) ++= Seq("-groups", "-implicits", "-no-link-warnin
 
 enablePlugins(ProtobufPlugin)
 
-val AkkaVersion = "2.5.19"
-val AkkaHttpVersion = "10.1.6"
+val AkkaVersion = "2.5.21"
+val AkkaHttpVersion = "10.1.7"
 val ReactiveStreamsVersion = "1.0.2"
 val Specs2Version = "3.8.6" // Because of concurrency issues with specs2 3.8.7+
 
@@ -56,7 +56,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
   "org.apache.directory.studio" % "org.apache.commons.codec" % "1.8",
   "joda-time" % "joda-time" % "2.10.1",
-  "org.joda" % "joda-convert" % "2.1.2",
+  "org.joda" % "joda-convert" % "2.2.0",
   "org.mockito" % "mockito-all" % "1.10.19" % Test,
   "org.specs2" %% "specs2-core" % Specs2Version % Test,
   "org.specs2" %% "specs2-mock" % Specs2Version % Test)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.8

--- a/src/test/scala/eventstore/StreamSourceSpec.scala
+++ b/src/test/scala/eventstore/StreamSourceSpec.scala
@@ -390,13 +390,15 @@ class StreamSourceSpec extends SourceSpec {
       override def eventNumber = Some(EventNumber(0))
     }
 
-    "temporarily unsubscribe when buffer is full" in new SourceScope {
+    "temporarily unsubscribe when buffer is full and ignore appearing events" in new SourceScope {
       connection expectMsg subscribeTo
       connection reply subscribeCompleted(0)
       connection reply streamEventAppeared(event1)
       connection reply streamEventAppeared(event2)
       connection reply streamEventAppeared(event3)
       connection expectMsg Unsubscribe
+      connection reply streamEventAppeared(event4)
+      connection reply streamEventAppeared(event5)
       connection reply Unsubscribed
       expectEvent(event1)
       expectEvent(event2)


### PR DESCRIPTION
 - change `SourceStageLogic` to ignore incoming
   events while unsubscribed instead of being
   unhandled, resulting in error log.

 - change `SourceStageLogic` to fail stage with
   `UnhandledException` when getting messages it
   does not expect.

 - bump dependencies in build and travis.

 - fix travis to fixed version of ES 4.1.2 as ES 5.x
   has changed protobuf protocol for scavenging.

 - adjust readme.