### PR TITLE
EventStore v5 protocol changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ jobs:
       scala: 2.12.8
       env: AKKA_TEST_TIMEFACTOR=1.5 AKKA_TEST_LOGLEVEL=OFF
       before_install:
-        - docker pull eventstore/eventstore:release-4.1.2
-        - docker run -d --rm --name eventstore-node -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=1200 eventstore/eventstore:release-4.1.2
+        - docker pull eventstore/eventstore:release-5.0.0
+        - docker run -d --rm --name eventstore-node -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=1200 eventstore/eventstore:release-5.0.0
       script:
         - sbt test:compile
         - travis_retry sbt it:test

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   </tr>
   <tr>
     <td><a href="https://eventstore.org">Event Store</a></td>
-    <td>v4.0.0 and higher is supported</td>
+    <td>v5.0.0 and higher is supported</td>
   </tr>  
 </table>
 
@@ -54,7 +54,7 @@ connection ! ReadEvent(EventStream.Id("my-stream"), EventNumber.First)
 
 #### Sbt
 ```scala
-libraryDependencies += "com.geteventstore" %% "eventstore-client" % "5.0.10"
+libraryDependencies += "com.geteventstore" %% "eventstore-client" % "6.0.0"
 ```
 
 #### Maven
@@ -62,7 +62,7 @@ libraryDependencies += "com.geteventstore" %% "eventstore-client" % "5.0.10"
 <dependency>
     <groupId>com.geteventstore</groupId>
     <artifactId>eventstore-client_${scala.version}</artifactId>
-    <version>5.0.10</version>
+    <version>6.0.0</version>
 </dependency>
 ```
 

--- a/src/main/protobuf/EventStoreMessages.proto
+++ b/src/main/protobuf/EventStoreMessages.proto
@@ -363,18 +363,16 @@ message NotHandled {
 message ScavengeDatabase {
 }
 
-message ScavengeDatabaseCompleted {
+message ScavengeDatabaseResponse {
 
   enum ScavengeResult {
-    Success = 0;
-    InProgress = 1;
-    Failed = 2;
+    Started      = 0;
+    InProgress   = 1;
+    Unauthorized = 2;
   }
 
   required ScavengeResult result = 1;
-  optional string error = 2;
-  required int32 total_time_ms = 3;
-  required int64 total_space_saved = 4;
+  optional string scavengeId = 2;
 }
 
 

--- a/src/main/scala/eventstore/EsException.scala
+++ b/src/main/scala/eventstore/EsException.scala
@@ -46,8 +46,7 @@ case class StreamNotFoundException(streamId: EventStream.Id) extends EsException
   extends EsException(s"Operation hasn't got response from server for $pack")
 
 @SerialVersionUID(1L) case object ScavengeInProgressException extends EsException
-
-@SerialVersionUID(1L) class ScavengeFailedException(message: String) extends EsException(message)
+@SerialVersionUID(1L) case object ScavengeUnauthorizedException extends EsException
 
 @SerialVersionUID(1L) class CommandNotExpectedException(message: String) extends EsException(message)
 

--- a/src/main/scala/eventstore/Message.scala
+++ b/src/main/scala/eventstore/Message.scala
@@ -331,7 +331,7 @@ sealed trait SubscribeCompleted extends In
   def getInstance = this
 }
 
-@SerialVersionUID(1L) case class ScavengeDatabaseCompleted(totalTime: FiniteDuration, totalSpaceSaved: Long) extends In
+@SerialVersionUID(1L) case class ScavengeDatabaseResponse(scavengeId: Option[String]) extends In
 
 @SerialVersionUID(1L) case object Authenticate extends Out {
   /**

--- a/src/main/scala/eventstore/SystemError.scala
+++ b/src/main/scala/eventstore/SystemError.scala
@@ -89,7 +89,7 @@ sealed trait ScavengeError extends SystemError
 
 object ScavengeError {
   @SerialVersionUID(1L) case object InProgress extends ScavengeError
-  @SerialVersionUID(1L) case class Failed(error: Option[String]) extends ScavengeError
+  @SerialVersionUID(1L) case object Unauthorized extends ScavengeError
 }
 
 sealed trait CreatePersistentSubscriptionError extends SystemError

--- a/src/main/scala/eventstore/operations/ScavengeDatabaseInspection.scala
+++ b/src/main/scala/eventstore/operations/ScavengeDatabaseInspection.scala
@@ -5,12 +5,12 @@ import ScavengeError._
 import Inspection.Decision._
 
 private[eventstore] object ScavengeDatabaseInspection
-    extends ErrorInspection[ScavengeDatabaseCompleted, ScavengeError] {
+    extends ErrorInspection[ScavengeDatabaseResponse, ScavengeError] {
 
   def decision(error: ScavengeError) = {
     val result = error match {
-      case InProgress => ScavengeInProgressException
-      case Failed(x)  => new ScavengeFailedException(x.orNull)
+      case InProgress   => ScavengeInProgressException
+      case Unauthorized => ScavengeUnauthorizedException
     }
     Fail(result)
   }

--- a/src/main/scala/eventstore/tcp/MarkerByte.scala
+++ b/src/main/scala/eventstore/tcp/MarkerByte.scala
@@ -70,7 +70,7 @@ object MarkerByte {
     0xC2 -> reader[StreamEventAppeared],
     0xC4 -> readerTry[Unsubscribed.type],
 
-    0xD1 -> readerTry[ScavengeDatabaseCompleted],
+    0xD1 -> readerTry[ScavengeDatabaseResponse],
 
     0xF0 -> readerFailure(BadRequest),
     0xF1 -> readerFailure[NotHandled],

--- a/src/test/scala/eventstore/ScavengeITest.scala
+++ b/src/test/scala/eventstore/ScavengeITest.scala
@@ -8,22 +8,16 @@ class ScavengeITest extends TestConnection {
   "scavenge" should {
     "scavenge database" in new TestConnectionScope {
       actor ! ScavengeDatabase
-      expectMsgType[ScavengeDatabaseCompleted]
+      expectMsgType[ScavengeDatabaseResponse]
     }
 
     "fail if scavenge is in progress" in new TestConnectionScope {
       val probe = TestProbe()
       actor.tell(ScavengeDatabase, probe.ref)
-
-      // Multiple commands are due to ES completing
-      // scavenge instantly, hence we are trying to
-      // win a race.
-
-      actor ! ScavengeDatabase
       actor ! ScavengeDatabase
       expectEsException() must throwA(ScavengeInProgressException)
 
-      probe.expectMsgType[ScavengeDatabaseCompleted]
+      probe.expectMsgType[ScavengeDatabaseResponse]
     }
   }
 }

--- a/src/test/scala/eventstore/operations/ScavengeDatabaseInspectionSpec.scala
+++ b/src/test/scala/eventstore/operations/ScavengeDatabaseInspectionSpec.scala
@@ -1,7 +1,7 @@
 package eventstore
 package operations
 
-import eventstore.ScavengeError.{ InProgress, Failed }
+import eventstore.ScavengeError.{ InProgress, Unauthorized }
 import eventstore.operations.Inspection.Decision.{ Fail, Stop }
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -13,7 +13,7 @@ class ScavengeDatabaseInspectionSpec extends Specification with Mockito {
   "ScavengeDatabaseInspection" should {
 
     "handle ScavengeDatabaseCompleted" in {
-      inspection(Success(mock[ScavengeDatabaseCompleted])) mustEqual Stop
+      inspection(Success(mock[ScavengeDatabaseResponse])) mustEqual Stop
     }
 
     "handle InProgress" in {
@@ -21,9 +21,8 @@ class ScavengeDatabaseInspectionSpec extends Specification with Mockito {
     }
 
     "handle Failed" in {
-      inspection(Failure(Failed(None))) must beLike {
-        case Fail(_: ScavengeFailedException) => ok
-      }
+      inspection(Failure(Unauthorized)) mustEqual Fail(ScavengeUnauthorizedException)
     }
+
   }
 }


### PR DESCRIPTION
 - ESv5 has changed protobuf protocol for scavenging,
   so this is a response to that.

 - bump major version of client as this is a breaking
   change.

 - set travis to use ESv5.

 - update the readme.