### PR TITLE
operations: decouple actor client from operation

### DIFF
--- a/src/main/scala/eventstore/operations/RetryableOperation.scala
+++ b/src/main/scala/eventstore/operations/RetryableOperation.scala
@@ -4,12 +4,12 @@ package operations
 import eventstore.operations.OnIncoming._
 import scala.util.Try
 
-private[eventstore] case class RetryableOperation(
-    operation:   Operation,
+private[eventstore] case class RetryableOperation[C](
+    operation:   Operation[C],
     retriesLeft: Int,
     maxRetries:  Int,
     ongoing:     Boolean
-) extends Operation {
+) extends Operation[C] {
 
   def id = operation.id
 
@@ -53,15 +53,15 @@ private[eventstore] case class RetryableOperation(
       else Stop(new RetriesLimitReachedException(s"Operation $pack reached retries limit: $maxRetries"))
   }
 
-  private def decrement(x: Operation) = copy(operation = x, retriesLeft = retriesLeft - 1)
+  private def decrement(x: Operation[C]) = copy(operation = x, retriesLeft = retriesLeft - 1)
 
-  private def reset(x: Operation) = copy(operation = x, retriesLeft = maxRetries)
+  private def reset(x: Operation[C]) = copy(operation = x, retriesLeft = maxRetries)
 
-  private def wrap(x: Operation) = copy(operation = x)
+  private def wrap(x: Operation[C]) = copy(operation = x)
 }
 
 private[eventstore] object RetryableOperation {
-  def apply(operation: Operation, maxRetries: Int, ongoing: Boolean): RetryableOperation = {
+  def apply[C](operation: Operation[C], maxRetries: Int, ongoing: Boolean): RetryableOperation[C] = {
     RetryableOperation(operation, maxRetries, maxRetries, ongoing)
   }
 }

--- a/src/test/scala/eventstore/ContentTypeITest.scala
+++ b/src/test/scala/eventstore/ContentTypeITest.scala
@@ -3,8 +3,9 @@ package eventstore
 import ContentType._
 
 class ContentTypeITest extends TestConnection {
+
   // TODO report issue to @gregoryyoung
-  val broken = "Does not work in 3.0.0rc9, EventStore always returns Data's ContentType for Metadata"
+  val broken = "Does not work in 5.0.0, EventStore always returns Data's ContentType for Metadata"
 
   "content type" should {
     "be correctly stored and retrieved for Binary/Binary" in new ContentTypeScope {

--- a/src/test/scala/eventstore/ScavengeITest.scala
+++ b/src/test/scala/eventstore/ScavengeITest.scala
@@ -1,23 +1,16 @@
 package eventstore
 
-import akka.testkit.TestProbe
-
 class ScavengeITest extends TestConnection {
   sequential
 
   "scavenge" should {
-    "scavenge database" in new TestConnectionScope {
+
+    "scavenge database and fail if in progress" in new TestConnectionScope {
       actor ! ScavengeDatabase
       expectMsgType[ScavengeDatabaseResponse]
-    }
-
-    "fail if scavenge is in progress" in new TestConnectionScope {
-      val probe = TestProbe()
-      actor.tell(ScavengeDatabase, probe.ref)
       actor ! ScavengeDatabase
       expectEsException() must throwA(ScavengeInProgressException)
-
-      probe.expectMsgType[ScavengeDatabaseResponse]
     }
+
   }
 }

--- a/src/test/scala/eventstore/operations/OperationSpec.scala
+++ b/src/test/scala/eventstore/operations/OperationSpec.scala
@@ -1,14 +1,15 @@
 package eventstore
 package operations
 
-import akka.actor.ActorRef
-import eventstore.tcp.Client
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
 trait OperationSpec extends Specification {
 
   protected trait OperationScope extends Scope {
-    val client: Client = Client(ActorRef.noSender)
+    val client: Client = ()
   }
+
+  type Client = Unit
+
 }

--- a/src/test/scala/eventstore/operations/PersistentSubscriptionOperationSpec.scala
+++ b/src/test/scala/eventstore/operations/PersistentSubscriptionOperationSpec.scala
@@ -124,13 +124,13 @@ class PersistentSubscriptionOperationSpec extends OperationSpec {
 
     "become connecting on disconnected" in new ConnectedScope {
       operation.disconnected must beLike {
-        case OnDisconnected.Continue(x: PersistentSubscriptionOperation.Connecting) if x.version == 1 => ok // Should be Connecting <= Persistent's version of subscribing.
+        case OnDisconnected.Continue(x: PersistentSubscriptionOperation.Connecting[Client]) if x.version == 1 => ok // Should be Connecting <= Persistent's version of subscribing.
       }
     }
 
     "become connected on connected and retry" in new ConnectedScope {
       operation.connected must beLike {
-        case OnConnected.Retry(x: PersistentSubscriptionOperation.Connecting, `pack`) if x.version == 1 => ok
+        case OnConnected.Retry(x: PersistentSubscriptionOperation.Connecting[Client], `pack`) if x.version == 1 => ok
       }
     }
 

--- a/src/test/scala/eventstore/operations/SubscriptionOperationSpec.scala
+++ b/src/test/scala/eventstore/operations/SubscriptionOperationSpec.scala
@@ -166,7 +166,7 @@ class SubscriptionOperationSpec extends OperationSpec {
     "become subscribing on disconnected" in foreach(streams) { implicit stream =>
       new SubscribedScope {
         operation.disconnected must beLike {
-          case OnDisconnected.Continue(x: SubscriptionOperation.Subscribing) if x.version == 1 => ok
+          case OnDisconnected.Continue(x: SubscriptionOperation.Subscribing[Client]) if x.version == 1 => ok
         }
       }
     }
@@ -174,7 +174,7 @@ class SubscriptionOperationSpec extends OperationSpec {
     "become subscribing on connected and retry" in foreach(streams) { implicit stream =>
       new SubscribedScope {
         operation.connected must beLike {
-          case OnConnected.Retry(x: SubscriptionOperation.Subscribing, `pack`) if x.version == 1 => ok
+          case OnConnected.Retry(x: SubscriptionOperation.Subscribing[Client], `pack`) if x.version == 1 => ok
         }
       }
     }


### PR DESCRIPTION
- parameterize client of `Operation` such that it
   not tied to a concrete implementation.

 - adjust tests and code accordingly.

 - fix `ScavengeITest` for failing tests
   that happens when first test scavenge
   not completes before second test runs.