### PR TITLE
date: replace joda with java.time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,8 +54,6 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.3",
   "io.spray" %%  "spray-json" % "1.3.5",
   "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-  "joda-time" % "joda-time" % "2.10.1",
-  "org.joda" % "joda-convert" % "2.2.0",
   "org.scodec" %% "scodec-bits" % "1.1.9",
   "org.mockito" % "mockito-all" % "1.10.19" % Test,
   "org.specs2" %% "specs2-core" % Specs2Version % Test,

--- a/src/main/scala/eventstore/Event.scala
+++ b/src/main/scala/eventstore/Event.scala
@@ -1,7 +1,7 @@
 package eventstore
 
 import java.util.UUID
-import org.joda.time.DateTime
+import java.time.ZonedDateTime
 import scala.PartialFunction.{ cond, condOpt }
 
 sealed trait Event extends Ordered[Event] {
@@ -9,7 +9,7 @@ sealed trait Event extends Ordered[Event] {
   def number: EventNumber.Exact
   def data: EventData
   def record: EventRecord
-  def created: Option[DateTime]
+  def created: Option[ZonedDateTime]
 
   def compare(that: Event) = this.number.value compare that.number.value
 
@@ -39,7 +39,7 @@ object Event {
     streamId: EventStream.Id,
     number:   EventNumber.Exact,
     data:     EventData,
-    created:  Option[DateTime]  = None
+    created:  Option[ZonedDateTime]  = None
 ) extends Event {
   def record = this
 }

--- a/src/main/scala/eventstore/cluster/ClusterInfo.scala
+++ b/src/main/scala/eventstore/cluster/ClusterInfo.scala
@@ -2,7 +2,7 @@ package eventstore
 package cluster
 
 import java.net.InetSocketAddress
-
+import java.time.ZonedDateTime
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.HostConnectionPool
 import akka.stream.ActorMaterializer
@@ -10,8 +10,6 @@ import akka.stream.scaladsl._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import org.joda.time.DateTime
-
 import scala.collection.concurrent.TrieMap
 import scala.concurrent._
 import scala.util.Try
@@ -60,7 +58,7 @@ object ClusterInfo {
 @SerialVersionUID(1L)
 case class MemberInfo(
     instanceId:         Uuid,
-    timestamp:          DateTime,
+    timestamp:          ZonedDateTime,
     state:              NodeState,
     isAlive:            Boolean,
     internalTcp:        InetSocketAddress,

--- a/src/main/scala/eventstore/tcp/EventStoreProtoFormats.scala
+++ b/src/main/scala/eventstore/tcp/EventStoreProtoFormats.scala
@@ -1,14 +1,14 @@
 package eventstore
 package tcp
 
-import eventstore.ReadDirection.{ Backward, Forward }
-import eventstore.proto.{ EventStoreMessages ⇒ j, _ }
-import eventstore.util.DefaultFormats
-import eventstore.{ PersistentSubscription ⇒ Ps }
-import org.joda.time.DateTime
+import java.time.{Instant, ZoneId, ZonedDateTime}
 import scala.collection.JavaConverters._
 import scala.language.reflectiveCalls
 import scala.util.Try
+import eventstore.ReadDirection.{Backward, Forward}
+import eventstore.proto.{EventStoreMessages => j, _}
+import eventstore.util.DefaultFormats
+import eventstore.{PersistentSubscription => Ps}
 
 object EventStoreProtoFormats extends EventStoreProtoFormats
 
@@ -115,7 +115,9 @@ trait EventStoreProtoFormats extends DefaultProtoFormats with DefaultFormats {
           data = Content(byteString(x.getData), ContentType(x.getDataContentType)),
           metadata = Content(byteString(x.getMetadata), ContentType(x.getMetadataContentType))
         ),
-        created = option(x.hasCreatedEpoch, new DateTime(x.getCreatedEpoch))
+        created = option(
+          x.hasCreatedEpoch, ZonedDateTime.ofInstant(Instant.ofEpochMilli(x.getCreatedEpoch), ZoneId.systemDefault)
+        )
       )
     }
   }

--- a/src/test/scala/eventstore/ResolvedEventSpec.scala
+++ b/src/test/scala/eventstore/ResolvedEventSpec.scala
@@ -1,13 +1,13 @@
 package eventstore
 
-import org.joda.time.DateTime
+import java.time.ZonedDateTime
 import org.specs2.mutable.Specification
 
 class ResolvedEventSpec extends Specification {
   "ResolvedEvent" should {
     "fallback to resolved event rather to link itself" in {
-      val event = EventRecord(EventStream.Id("streamId1"), EventNumber.Exact(1), EventData("test"), Some(DateTime.now))
-      val link = EventRecord(EventStream.Id("streamId2"), EventNumber.Exact(2), event.link(), Some(DateTime.now().plusSeconds(5)))
+      val event = EventRecord(EventStream.Id("streamId1"), EventNumber.Exact(1), EventData("test"), Some(ZonedDateTime.now))
+      val link = EventRecord(EventStream.Id("streamId2"), EventNumber.Exact(2), event.link(), Some(ZonedDateTime.now().plusSeconds(5)))
       val resolvedEvent = ResolvedEvent(event, link)
 
       resolvedEvent.streamId mustEqual event.streamId

--- a/src/test/scala/eventstore/TestConnection.scala
+++ b/src/test/scala/eventstore/TestConnection.scala
@@ -4,7 +4,7 @@ import akka.actor.Status.Failure
 import akka.testkit._
 import eventstore.ReadDirection._
 import eventstore.tcp.ConnectionActor
-import org.joda.time.DateTime
+import java.time.ZonedDateTime
 import spray.json.{ JsNumber, JsObject }
 
 import scala.concurrent.duration._
@@ -13,7 +13,7 @@ abstract class TestConnection extends util.ActorSpec {
 
   abstract class TestConnectionScope extends ActorScope {
     val streamId = newStreamId
-    val date = DateTime.now
+    val date = ZonedDateTime.now
 
     val streamMetadata = ByteString(TestConnection.this.getClass.getSimpleName)
     val actor = system.actorOf(ConnectionActor.props())

--- a/src/test/scala/eventstore/cluster/ClusterDiscovererActorSpec.scala
+++ b/src/test/scala/eventstore/cluster/ClusterDiscovererActorSpec.scala
@@ -2,11 +2,11 @@ package eventstore
 package cluster
 
 import java.net.InetSocketAddress
+import java.time.ZonedDateTime
 import akka.testkit.TestProbe
 import akka.util.Timeout
 import akka.actor.Status.Failure
 import akka.pattern.ask
-import org.joda.time.DateTime
 import org.specs2.mock.Mockito
 import ClusterDiscovererActor._
 import GossipSeedsOrDns.ClusterDns
@@ -461,7 +461,7 @@ class ClusterDiscovererActorSpec extends util.ActorSpec with Mockito {
       isAlive: Boolean           = true
     ): MemberInfo = MemberInfo(
       instanceId = ids(address),
-      timestamp = DateTime.now,
+      timestamp = ZonedDateTime.now,
       state = state,
       isAlive = isAlive,
       internalTcp = address,

--- a/src/test/scala/eventstore/cluster/ClusterInfoSpec.scala
+++ b/src/test/scala/eventstore/cluster/ClusterInfoSpec.scala
@@ -1,7 +1,7 @@
 package eventstore
 package cluster
 
-import org.joda.time.DateTime
+import java.time.ZonedDateTime
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import eventstore.cluster.NodeState._
@@ -39,7 +39,7 @@ class ClusterInfoSpec extends Specification {
 
     def member(state: NodeState = NodeState.Master, isAlive: Boolean = true) = MemberInfo(
       instanceId = randomUuid,
-      timestamp = DateTime.now,
+      timestamp = ZonedDateTime.now,
       state = state,
       isAlive = isAlive,
       internalTcp = address,

--- a/src/test/scala/eventstore/cluster/ClusterProtocolSpec.scala
+++ b/src/test/scala/eventstore/cluster/ClusterProtocolSpec.scala
@@ -2,7 +2,7 @@ package eventstore
 package cluster
 
 import eventstore.cluster.NodeState.{ Master, Slave }
-import org.joda.time.{ DateTime, DateTimeZone }
+import java.time.{ZonedDateTime, ZoneOffset}
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import spray.json._
@@ -37,7 +37,7 @@ class ClusterProtocolSpec extends Specification {
     val clusterInfo = ClusterInfo("127.0.0.1" :: 2113, List(
       MemberInfo(
         instanceId = "4534f211-10af-45f1-87c0-8398215328be".uuid,
-        timestamp = new DateTime(2014, 9, 24, 19, 53, 18, 590, DateTimeZone.UTC),
+        timestamp = ZonedDateTime.of(2014, 9, 24, 19, 53, 18, 590550000, ZoneOffset.UTC),
         state = Slave,
         isAlive = false,
         internalTcp = "127.0.0.1" :: 3111,
@@ -56,7 +56,7 @@ class ClusterProtocolSpec extends Specification {
       ),
       MemberInfo(
         instanceId = "8f680215-3abe-4aed-9d06-c5725776303d".uuid,
-        timestamp = new DateTime(2015, 1, 29, 10, 23, 9, 41, DateTimeZone.UTC),
+        timestamp = ZonedDateTime.of(2015, 1, 29, 10, 23, 9, 41562100, ZoneOffset.UTC),
         state = Master,
         isAlive = true,
         internalTcp = "127.0.0.1" :: 2111,
@@ -75,7 +75,7 @@ class ClusterProtocolSpec extends Specification {
       ),
       MemberInfo(
         instanceId = "44baf256-55a4-4ccc-b6ef-7bd383c88991".uuid,
-        timestamp = new DateTime(2015, 1, 26, 19, 52, 40, DateTimeZone.UTC),
+        timestamp = ZonedDateTime.of(2015, 1, 26, 19, 52, 40, 0, ZoneOffset.UTC),
         state = Slave,
         isAlive = true,
         internalTcp = "127.0.0.1" :: 1111,

--- a/src/test/scala/eventstore/cluster/DateFormatSpec.scala
+++ b/src/test/scala/eventstore/cluster/DateFormatSpec.scala
@@ -1,30 +1,39 @@
-package eventstore.cluster
+package eventstore
+package cluster
 
-import org.joda.time.{ DateTime, DateTimeZone }
+import java.time._
 import org.specs2.mutable.Specification
 import eventstore.cluster.ClusterProtocol.DateTimeFormat
 import spray.json._
 
 class DateFormatSpec extends Specification {
+
   "DateFormat" should {
+
     "parse 2015-01-26T19:52:40Z" in {
-      val expected = new DateTime(2015, 1, 26, 19, 52, 40, DateTimeZone.UTC)
+      val expected = ZonedDateTime.of(2015, 1, 26, 19, 52, 40, 0, ZoneOffset.UTC)
       DateTimeFormat.read(JsString("2015-01-26T19:52:40Z")) mustEqual expected
     }
 
     "parse 2014-09-24T19:53:20.035753Z" in {
-      val expected = new DateTime(2014, 9, 24, 19, 53, 20, 35, DateTimeZone.UTC)
+      val expected = ZonedDateTime.of(2014, 9, 24, 19, 53, 20, 35753000, ZoneOffset.UTC)
       DateTimeFormat.read(JsString("2014-09-24T19:53:20.035753Z")) mustEqual expected
     }
 
     "parse 2015-01-29T12:28:54.8302665Z" in {
-      val expected = new DateTime(2015, 1, 29, 12, 28, 54, 830, DateTimeZone.UTC)
+      val expected = ZonedDateTime.of(2015, 1, 29, 12, 28, 54, 830266500, ZoneOffset.UTC)
       DateTimeFormat.read(JsString("2015-01-29T12:28:54.8302665Z")) mustEqual expected
     }
 
-    "parse 2017-03-26T02:28:54.8302665Z" in {
-      val expected = new DateTime(2017, 3, 26, 2, 28, 54, 830, DateTimeZone.UTC)
-      DateTimeFormat.read(JsString("2017-03-26T02:28:54.8302665Z")) mustEqual expected
+    "parse 2017-03-26T02:28:54.830Z" in {
+      val expected = ZonedDateTime.of(2017, 3, 26, 2, 28, 54, 830 * 1000000, ZoneOffset.UTC)
+      DateTimeFormat.read(JsString("2017-03-26T02:28:54.830Z")) mustEqual expected
     }
+
+    "parse 2019-03-11T11:44:59.034Z" in {
+      val expected = ZonedDateTime.of(2019, 3, 11, 11, 44, 59, 34 * 1000000, ZoneOffset.UTC)
+      DateTimeFormat.read(JsString("2019-03-11T11:44:59.034Z")) mustEqual expected
+    }
+
   }
 }


### PR DESCRIPTION
 - remove usage of joda libraries and replace
   with java.time.*

 - using `ZoneId.systemDefault` for `created` field
   on `EventRecord`. This is same behavior as joda
   `new DateTime(x.getCreatedEpoch)`.

 - Note: This is a breaking change as `created`
   on `Event` is changed from joda to java.time.