### PR TITLE
misc: deprecation, type alias & final case class

### DIFF
--- a/client/src/main/scala/eventstore/akka/AbstractPersistentSubscriptionActor.scala
+++ b/client/src/main/scala/eventstore/akka/AbstractPersistentSubscriptionActor.scala
@@ -4,7 +4,7 @@ package akka
 import _root_.akka.actor.{Actor, ActorLogging, ActorRef}
 import eventstore.{PersistentSubscription => PS}
 
-trait AbstractPersistentSubscriptionActor[T] extends Actor with ActorLogging {
+private[eventstore] trait AbstractPersistentSubscriptionActor[T] extends Actor with ActorLogging {
   def groupName: String
   def client: ActorRef
   def connection: ActorRef

--- a/client/src/main/scala/eventstore/akka/AbstractSubscriptionActor.scala
+++ b/client/src/main/scala/eventstore/akka/AbstractSubscriptionActor.scala
@@ -4,8 +4,7 @@ package akka
 import _root_.akka.actor.Status.Failure
 import _root_.akka.actor.{Actor, ActorIdentity, ActorLogging, ActorRef, Identify}
 
-
-trait AbstractSubscriptionActor[T] extends Actor with ActorLogging {
+private[eventstore] trait AbstractSubscriptionActor[T] extends Actor with ActorLogging {
   def client: ActorRef
   def connection: ActorRef
   def streamId: EventStream
@@ -65,11 +64,4 @@ trait AbstractSubscriptionActor[T] extends Actor with ActorLogging {
     if (ready) receive
     else rcvFailure or rcvReady(receive)
   }
-}
-
-@SerialVersionUID(1L) case object LiveProcessingStarted {
-  /**
-   * Java API
-   */
-  def getInstance = this
 }

--- a/client/src/main/scala/eventstore/akka/ActorCloseable.scala
+++ b/client/src/main/scala/eventstore/akka/ActorCloseable.scala
@@ -4,8 +4,6 @@ package akka
 import java.io.Closeable
 import _root_.akka.actor.{PoisonPill, ActorRef}
 
-final case class ActorCloseable(actor: ActorRef) extends Closeable {
-  def close() = {
-    actor ! PoisonPill
-  }
+private[eventstore] final case class ActorCloseable(actor: ActorRef) extends Closeable {
+  def close() = actor ! PoisonPill
 }

--- a/client/src/main/scala/eventstore/akka/EsConnection.scala
+++ b/client/src/main/scala/eventstore/akka/EsConnection.scala
@@ -29,15 +29,6 @@ class EsConnection(
 
   implicit val timeout = Timeout(settings.operationTimeout)
 
-  @deprecated("use `apply` instead", "3.0.0")
-  def future[OUT <: Out, IN <: In](out: OUT, credentials: Option[UserCredentials] = None)(
-    implicit
-    outIn: ClassTags[OUT, IN]
-  ): Future[IN] = {
-
-    apply(out, credentials)(outIn, factory.dispatcher)
-  }
-
   def apply[OUT <: Out, IN <: In](out: OUT, credentials: Option[UserCredentials] = None)(
     implicit
     outIn: ClassTags[OUT, IN],

--- a/client/src/main/scala/eventstore/akka/EsTransaction.scala
+++ b/client/src/main/scala/eventstore/akka/EsTransaction.scala
@@ -12,7 +12,7 @@ trait EsTransaction {
   def commit(): Future[Unit]
 }
 
-object EsTransaction {
+private[eventstore] object EsTransaction {
   implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
   def start(actor: ActorRef)(implicit timeout: Timeout): Future[EsTransaction] = {
@@ -25,7 +25,9 @@ object EsTransaction {
     EsTransactionForActor(transactionId, actor)
 }
 
-final case class EsTransactionForActor(transactionId: Long, actor: ActorRef)(implicit timeout: Timeout) extends EsTransaction {
+private[eventstore] final case class EsTransactionForActor(
+  transactionId: Long, actor: ActorRef)(implicit timeout: Timeout
+) extends EsTransaction {
 
   import TransactionActor._
   import EsTransaction.executionContext

--- a/client/src/main/scala/eventstore/akka/LiveProcessingStarted.scala
+++ b/client/src/main/scala/eventstore/akka/LiveProcessingStarted.scala
@@ -1,0 +1,10 @@
+package eventstore
+package akka
+
+@SerialVersionUID(1L)
+case object LiveProcessingStarted {
+  /**
+   * Java API
+   */
+  def getInstance = this
+}

--- a/client/src/main/scala/eventstore/akka/OverflowStrategy.scala
+++ b/client/src/main/scala/eventstore/akka/OverflowStrategy.scala
@@ -1,21 +1,32 @@
 package eventstore
 package akka
 
-import _root_.akka.stream.{ OverflowStrategy => Akka }
+import _root_.akka.stream.{ OverflowStrategy => AOS }
 
-sealed trait OverflowStrategy {
-  def toAkka: _root_.akka.stream.OverflowStrategy
-}
-
+sealed trait OverflowStrategy
 object OverflowStrategy {
+
   lazy val Values: Set[OverflowStrategy] = Set(DropHead, DropTail, DropBuffer, DropNew, Fail)
   private lazy val map = Values.map(x => (x.toString.toLowerCase, x)).toMap
 
-  def apply(x: String): OverflowStrategy = map getOrElse (x.toLowerCase, sys error s"No OverflowStrategy found by $x")
+  def apply(x: String): OverflowStrategy =
+    map getOrElse (x.toLowerCase, sys error s"No OverflowStrategy found by $x")
 
-  case object DropHead extends OverflowStrategy { def toAkka = Akka.dropHead }
-  case object DropTail extends OverflowStrategy { def toAkka = Akka.dropTail }
-  case object DropBuffer extends OverflowStrategy { def toAkka = Akka.dropBuffer }
-  case object DropNew extends OverflowStrategy { def toAkka = Akka.dropNew }
-  case object Fail extends OverflowStrategy { def toAkka = Akka.fail }
+  case object DropHead   extends OverflowStrategy
+  case object DropTail   extends OverflowStrategy
+  case object DropBuffer extends OverflowStrategy
+  case object DropNew    extends OverflowStrategy
+  case object Fail       extends OverflowStrategy
+
+  ///
+
+  private[eventstore] implicit class OverflowStrategyOps(os: OverflowStrategy) {
+    def toAkka: AOS = os match {
+      case DropHead   => AOS.dropHead
+      case DropTail   => AOS.dropTail
+      case DropBuffer => AOS.dropBuffer
+      case DropNew    => AOS.dropNew
+      case Fail       => AOS.fail
+    }
+  }
 }

--- a/client/src/main/scala/eventstore/akka/PersistentSubscriptionActor.scala
+++ b/client/src/main/scala/eventstore/akka/PersistentSubscriptionActor.scala
@@ -9,6 +9,7 @@ import eventstore.PersistentSubscription.{Ack, Nak}
 import eventstore.akka.PersistentSubscriptionActor._
 
 object PersistentSubscriptionActor {
+
   def props(
     connection:  ActorRef,
     client:      ActorRef,
@@ -47,7 +48,7 @@ object PersistentSubscriptionActor {
   final case class ManualNak(eventId: Uuid)
 }
 
-class PersistentSubscriptionActor private (
+private[eventstore] class PersistentSubscriptionActor private (
     val connection:  ActorRef,
     val client:      ActorRef,
     val streamId:    EventStream,

--- a/client/src/main/scala/eventstore/akka/SubscriptionObserverActor.scala
+++ b/client/src/main/scala/eventstore/akka/SubscriptionObserverActor.scala
@@ -6,8 +6,9 @@ import _root_.akka.actor.Status.Failure
 import _root_.akka.actor.{Actor, Props}
 
 object SubscriptionObserverActor {
+
   def props[T](observer: SubscriptionObserver[T])(implicit tag: ClassTag[T]): Props =
-    Props(classOf[SubscriptionObserverActor[T]], observer, tag)
+    Props(new SubscriptionObserverActor[T](observer, tag))
 
   /**
    * Java API
@@ -15,7 +16,9 @@ object SubscriptionObserverActor {
   def getProps[T](observer: SubscriptionObserver[T], clazz: Class[T]): Props = props(observer)(ClassTag(clazz))
 }
 
-class SubscriptionObserverActor[T](observer: SubscriptionObserver[T], tag: ClassTag[T]) extends Actor {
+private[eventstore] class SubscriptionObserverActor[T](observer: SubscriptionObserver[T], tag: ClassTag[T])
+  extends Actor {
+
   val closeable = ActorCloseable(self)
 
   def receive = {

--- a/client/src/main/scala/eventstore/akka/cluster/ClusterInfoOf.scala
+++ b/client/src/main/scala/eventstore/akka/cluster/ClusterInfoOf.scala
@@ -16,7 +16,7 @@ import _root_.akka.http.scaladsl.unmarshalling.Unmarshal
 import _root_.akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import eventstore.cluster.ClusterInfo
 
-object ClusterInfoOf {
+private[eventstore] object ClusterInfoOf {
 
   type FutureFunc = InetSocketAddress => Future[ClusterInfo]
 

--- a/client/src/main/scala/eventstore/akka/cluster/ClusterJsonProtocol.scala
+++ b/client/src/main/scala/eventstore/akka/cluster/ClusterJsonProtocol.scala
@@ -8,7 +8,7 @@ import eventstore.syntax._
 import eventstore.cluster.{ClusterInfo, MemberInfo, NodeState}
 import spray.json._
 
-object ClusterJsonProtocol extends DefaultJsonProtocol {
+private[eventstore] object ClusterJsonProtocol extends DefaultJsonProtocol {
 
   implicit object UuidFormat extends JsonFormat[Uuid] {
     def write(x: Uuid): JsValue = JsString(x.toString)

--- a/client/src/main/scala/eventstore/akka/package.scala
+++ b/client/src/main/scala/eventstore/akka/package.scala
@@ -4,6 +4,13 @@ import _root_.akka.actor.Actor
 
 package object akka {
 
+  private[eventstore] def deprecationMsg(name: String) =
+    s"$name has been moved from eventstore.$name to eventstore.akka.$name. " +
+    s"Please update your imports, as this deprecated type alias will be " +
+    s"removed in a future version of EventStore.JVM."
+
+  ///
+
   def randomUuid: Uuid = eventstore.util.uuid.randomUuid
 
   implicit class RichPartialFunction(val self: Actor.Receive) extends AnyVal {

--- a/client/src/main/scala/eventstore/akka/tcp/BidiFraming.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/BidiFraming.scala
@@ -8,7 +8,7 @@ import _root_.akka.stream.scaladsl.Framing.FramingException
 import _root_.akka.stream.scaladsl.{BidiFlow, Flow, Framing, Keep}
 import _root_.akka.util.ByteString
 
-object BidiFraming {
+private[eventstore] object BidiFraming {
 
   def apply(fieldLength: Int, maxFrameLength: Int)(implicit byteOrder: ByteOrder): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] = {
 

--- a/client/src/main/scala/eventstore/akka/tcp/BidiLogging.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/BidiLogging.scala
@@ -8,7 +8,7 @@ import _root_.akka.event.LoggingAdapter
 import _root_.akka.stream.scaladsl.BidiFlow
 import eventstore.tcp.{PackIn, PackOut}
 
-object BidiLogging {
+private[eventstore] object BidiLogging {
 
   def apply(log: LoggingAdapter): BidiFlow[PackIn, PackIn, PackOut, PackOut, NotUsed] = {
 

--- a/client/src/main/scala/eventstore/akka/tcp/BidiReply.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/BidiReply.scala
@@ -6,7 +6,7 @@ import _root_.akka.NotUsed
 import _root_.akka.stream.BidiShape
 import _root_.akka.stream.scaladsl.{ BidiFlow, Broadcast, Flow, GraphDSL, Merge }
 
-object BidiReply {
+private[eventstore] object BidiReply {
   def apply[I, O](pf: PartialFunction[I, O]): BidiFlow[I, I, O, O, NotUsed] = BidiFlow.fromGraph {
     GraphDSL.create() { implicit builder =>
       import GraphDSL.Implicits._

--- a/client/src/main/scala/eventstore/akka/tcp/EventStoreFlow.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/EventStoreFlow.scala
@@ -14,7 +14,7 @@ import eventstore.tcp._
 import eventstore.tcp.EventStoreFormats._
 import eventstore.syntax._
 
-object EventStoreFlow {
+private[eventstore] object EventStoreFlow {
 
   def apply(
     heartbeatInterval: FiniteDuration,

--- a/client/src/main/scala/eventstore/package.scala
+++ b/client/src/main/scala/eventstore/package.scala
@@ -7,31 +7,34 @@ import java.{util => ju}
 package object eventstore {
 
   private val sinceVersion = "7.0.0"
-  private def updateMsg(name: String) =
-    s"$name has been moved from eventstore.$name to eventstore.akka.$name. " +
-    s"Please update your imports, as this deprecated type alias will be " +
-    s"removed in a future version of EventStore.JVM."
 
   type Uuid                = ju.UUID
 
-  @deprecated(updateMsg("EsConnection"), since = sinceVersion)
+  @deprecated(a.deprecationMsg("EsConnection"), since = sinceVersion)
   type EsConnection        = a.EsConnection
   val EsConnection         = a.EsConnection
 
-  @deprecated(updateMsg("EventStoreExtension"), since = sinceVersion)
+  @deprecated(a.deprecationMsg("EventStoreExtension"), since = sinceVersion)
   type EventStoreExtension = a.EventStoreExtension
   val EventStoreExtension  = a.EventStoreExtension
 
-  @deprecated(updateMsg("OverflowStrategy"), since = sinceVersion)
+  @deprecated(a.deprecationMsg("OverflowStrategy"), since = sinceVersion)
   type OverflowStrategy    = a.OverflowStrategy
   val OverflowStrategy     = a.OverflowStrategy
 
-  @deprecated(updateMsg("EsTransaction"), since = sinceVersion)
+  @deprecated(a.deprecationMsg("EsTransaction"), since = sinceVersion)
   type EsTransaction       = a.EsTransaction
   val EsTransaction        = a.EsTransaction
 
-  @deprecated(updateMsg("ProjectionsClient"), since = sinceVersion)
+  @deprecated(a.deprecationMsg("ProjectionsClient"), since = sinceVersion)
   type ProjectionsClient   = a.ProjectionsClient
   val ProjectionsClient    = a.ProjectionsClient
+
+  @deprecated(a.deprecationMsg("PersistentSubscriptionActor"), since = sinceVersion)
+  val PersistentSubscriptionActor  = a.PersistentSubscriptionActor
+
+  @deprecated(a.deprecationMsg("LiveProcessingStarted"), since = sinceVersion)
+  type LiveProcessingStarted = a.LiveProcessingStarted.type
+  val LiveProcessingStarted  = a.LiveProcessingStarted
 
 }

--- a/client/src/main/scala/eventstore/tcp/package.scala
+++ b/client/src/main/scala/eventstore/tcp/package.scala
@@ -1,0 +1,14 @@
+package eventstore
+
+import eventstore.{akka => a}
+
+// TODO(AHJ): Remove this package object after 7.1.0
+
+package object tcp extends TypeAliases {
+
+  private val sinceVersion = "7.0.0"
+
+  @deprecated(a.deprecationMsg("ConnectionActor"), since = sinceVersion)
+  val ConnectionActor = a.tcp.ConnectionActor
+
+}

--- a/client/src/test/scala/eventstore/akka/AbstractSubscriptionActorSpec.scala
+++ b/client/src/test/scala/eventstore/akka/AbstractSubscriptionActorSpec.scala
@@ -5,9 +5,8 @@ import scala.concurrent.duration._
 import _root_.akka.actor.Status.Failure
 import _root_.akka.actor.ActorRef
 import _root_.akka.testkit._
-import org.specs2.mock.Mockito
 
-abstract class AbstractSubscriptionActorSpec extends ActorSpec with Mockito {
+abstract class AbstractSubscriptionActorSpec extends ActorSpec {
 
   abstract class AbstractScope extends ActorScope {
     val duration = 1.second

--- a/client/src/test/scala/eventstore/akka/EsConnectionSpec.scala
+++ b/client/src/test/scala/eventstore/akka/EsConnectionSpec.scala
@@ -3,46 +3,46 @@ package akka
 
 import scala.util.Success
 import _root_.akka.actor.Status.Failure
-import org.specs2.mock.Mockito
 import testutil._
+import TestData._
 
-class EsConnectionSpec extends ActorSpec with Mockito {
+class EsConnectionSpec extends ActorSpec {
 
   "EventStoreConnection.future" should {
     "write events" in new TestScope {
-      verifyOutIn(mock[WriteEvents], mock[WriteEventsCompleted])
+      verifyOutIn(writeEvents, writeEventsCompleted)
     }
 
     "delete stream" in new TestScope {
-      verifyOutIn(mock[DeleteStream], DeleteStreamCompleted())
+      verifyOutIn(deleteStream, deleteStreamCompleted)
     }
 
     "transaction start" in new TestScope {
-      verifyOutIn(mock[TransactionStart], mock[TransactionStartCompleted])
+      verifyOutIn(transactionStart, transactionStartCompleted)
     }
 
     "transaction write" in new TestScope {
-      verifyOutIn(mock[TransactionWrite], mock[TransactionWriteCompleted])
+      verifyOutIn(transactionWrite, transactionWriteCompleted)
     }
 
     "transaction commit" in new TestScope {
-      verifyOutIn(mock[TransactionCommit], mock[TransactionCommitCompleted])
+      verifyOutIn(transactionCommit, transactionCommitCompleted)
     }
 
     "read event" in new TestScope {
-      verifyOutIn(mock[ReadEvent], mock[ReadEventCompleted])
+      verifyOutIn(readEvent, readEventCompleted)
     }
 
     "read stream events" in new TestScope {
-      verifyOutIn(mock[ReadStreamEvents], mock[ReadStreamEventsCompleted])
+      verifyOutIn(readStreamEvents, readStreamEventsCompleted)
     }
 
     "read all events" in new TestScope {
-      verifyOutIn(mock[ReadAllEvents], mock[ReadAllEventsCompleted])
+      verifyOutIn(readAllEvents, readAllEventsCompleted)
     }
 
     "subscribe to" in new TestScope {
-      verifyOutIn(mock[SubscribeTo], mock[SubscribeToStreamCompleted])
+      verifyOutIn(subscribeTo, subscribeToStreamCompleted)
     }
 
     "set stream metadata" in new TestScope {
@@ -77,15 +77,15 @@ class EsConnectionSpec extends ActorSpec with Mockito {
     }
 
     "create persistent subscription" in new TestScope {
-      verifyOutIn(mock[PersistentSubscription.Create], mock[PersistentSubscription.CreateCompleted.type])
+      verifyOutIn(psCreate, psCreateCompleted)
     }
 
     "update persistent subscription" in new TestScope {
-      verifyOutIn(mock[PersistentSubscription.Update], mock[PersistentSubscription.UpdateCompleted.type])
+      verifyOutIn(psUpdate, psUpdateCompleted)
     }
 
     "delete persistent subscription" in new TestScope {
-      verifyOutIn(mock[PersistentSubscription.Delete], mock[PersistentSubscription.DeleteCompleted.type])
+      verifyOutIn(psDelete, psDeleteCompleted)
     }
   }
 

--- a/client/src/test/scala/eventstore/akka/PersistentSubscriptionActorSpec.scala
+++ b/client/src/test/scala/eventstore/akka/PersistentSubscriptionActorSpec.scala
@@ -4,6 +4,7 @@ package akka
 import _root_.akka.actor.ActorRef
 import _root_.akka.testkit.TestActorRef
 import PersistentSubscription._
+import TestData.eventData
 
 class PersistentSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
   "PersistentSubscriptionActor" should {
@@ -112,7 +113,7 @@ class PersistentSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
 
     def expectNak(): Unit = connection.expectMsgType[Nak]
 
-    def newEvent(number: Long): Event = EventRecord(streamId, EventNumber.Exact(number), mock[EventData])
+    def newEvent(number: Long): Event = EventRecord(streamId, EventNumber.Exact(number), eventData)
 
     def eventAppeared(event: Event) =
       EventAppeared(event)

--- a/client/src/test/scala/eventstore/akka/StreamSubscriptionActorSpec.scala
+++ b/client/src/test/scala/eventstore/akka/StreamSubscriptionActorSpec.scala
@@ -458,7 +458,7 @@ class StreamSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
 
     def expectEvent(x: Event) = expectMsg(x)
 
-    def newEvent(number: Long): Event = EventRecord(streamId, EventNumber.Exact(number), mock[EventData])
+    def newEvent(number: Long): Event = EventRecord(streamId, EventNumber.Exact(number),TestData.eventData)
 
     def readEvents(x: Long) =
       ReadStreamEvents(streamId, EventNumber(x), readBatchSize, Forward, resolveLinkTos = resolveLinkTos)
@@ -466,7 +466,7 @@ class StreamSubscriptionActorSpec extends AbstractSubscriptionActorSpec {
     def readCompleted(next: Long, endOfStream: Boolean, events: Event*) = ReadStreamEventsCompleted(
       events = events.toList,
       nextEventNumber = EventNumber(next),
-      lastEventNumber = mock[EventNumber.Exact],
+      lastEventNumber = EventNumber.Exact(1L),
       endOfStream = endOfStream,
       lastCommitPosition = next.toLong,
       direction = Forward

--- a/client/src/test/scala/eventstore/akka/SubscriptionActorSpec.scala
+++ b/client/src/test/scala/eventstore/akka/SubscriptionActorSpec.scala
@@ -436,7 +436,7 @@ class SubscriptionActorSpec extends AbstractSubscriptionActorSpec {
 
     def expectEvent(x: IndexedEvent) = expectMsg(x)
 
-    def newEvent(x: Long) = IndexedEvent(mock[Event], Position.Exact(x))
+    def newEvent(x: Long) = IndexedEvent(TestData.eventRecord, Position.Exact(x))
 
     def readEvents(x: Long) = ReadAllEvents(Position(x), readBatchSize, Forward, resolveLinkTos = resolveLinkTos)
 

--- a/client/src/test/scala/eventstore/akka/TestData.scala
+++ b/client/src/test/scala/eventstore/akka/TestData.scala
@@ -1,0 +1,59 @@
+package eventstore
+package akka
+
+import eventstore.{PersistentSubscription ⇒ Ps}
+
+object TestData {
+
+  val streamId: EventStream.Id              = EventStream.Id("test")
+  val expectedAny: ExpectedVersion.Existing = ExpectedVersion.Any
+  val requireMaster: Boolean                = true
+  val resolveLinkTos: Boolean               = true
+  val psGroup: String                       = "test-group"
+  val hardDelete: Boolean                   = true
+  val exactN: EventNumber.Exact             = EventNumber.First
+  val exactP: Position.Exact                = Position.First
+  val readDirection: ReadDirection          = ReadDirection.Forward
+  val eventData: EventData                  = EventData("type", randomUuid, Content.Empty, Content.Empty)
+  val eventRecord: EventRecord              = EventRecord(streamId, exactN, eventData)
+  val indexedEvent: IndexedEvent            = IndexedEvent(eventRecord, Position.First)
+
+  def psCreate: Ps.Create = Ps.Create(streamId, psGroup)
+  def psCreateCompleted: Ps.CreateCompleted.type = Ps.CreateCompleted
+
+  def psUpdate: Ps.Update = Ps.Update(streamId, psGroup)
+  def psUpdateCompleted: Ps.UpdateCompleted.type = Ps.UpdateCompleted
+
+  def psDelete: Ps.Delete = Ps.Delete(streamId, psGroup)
+  def psDeleteCompleted: Ps.DeleteCompleted.type = Ps.DeleteCompleted
+
+  def writeEventsCompleted: WriteEventsCompleted = WriteEventsCompleted(None, None)
+  def writeEvents: WriteEvents = WriteEvents(streamId, Nil, expectedAny, requireMaster)
+
+  def deleteStream: DeleteStream = DeleteStream(streamId, expectedAny, hardDelete, requireMaster)
+  def deleteStreamCompleted: DeleteStreamCompleted = DeleteStreamCompleted(None)
+
+  def readEvent: ReadEvent = ReadEvent(streamId)
+  def readEventCompleted: ReadEventCompleted = ReadEventCompleted(eventRecord)
+
+  def readStreamEvents: ReadStreamEvents = ReadStreamEvents(streamId)
+  def readStreamEventsCompleted: ReadStreamEventsCompleted = ReadStreamEventsCompleted(Nil, exactN, exactN, true, 1L, readDirection)
+
+  def readAllEvents: ReadAllEvents = ReadAllEvents(exactP)
+  def readAllEventsCompleted: ReadAllEventsCompleted = ReadAllEventsCompleted(Nil, exactP, exactP, readDirection)
+
+  def scavengeDatabaseResponse: ScavengeDatabaseResponse = ScavengeDatabaseResponse(None)
+
+  def transactionCommit: TransactionCommit = TransactionCommit(1L, requireMaster)
+  def transactionCommitCompleted: TransactionCommitCompleted = TransactionCommitCompleted(1L)
+
+  def transactionStart: TransactionStart = TransactionStart(streamId, expectedAny, requireMaster)
+  def transactionStartCompleted: TransactionStartCompleted = TransactionStartCompleted(1L)
+
+  def transactionWrite: TransactionWrite = TransactionWrite(1L, Nil, requireMaster)
+  def transactionWriteCompleted: TransactionWriteCompleted = TransactionWriteCompleted(1L)
+
+  def subscribeTo: SubscribeTo = SubscribeTo(streamId, resolveLinkTos)
+  def subscribeToStreamCompleted: SubscribeToStreamCompleted = SubscribeToStreamCompleted(1L, None)
+
+}

--- a/client/src/test/scala/eventstore/akka/cluster/ClusterDiscovererActorSpec.scala
+++ b/client/src/test/scala/eventstore/akka/cluster/ClusterDiscovererActorSpec.scala
@@ -11,14 +11,13 @@ import _root_.akka.testkit.TestProbe
 import _root_.akka.util.Timeout
 import _root_.akka.actor.Status.Failure
 import _root_.akka.pattern.ask
-import org.specs2.mock.Mockito
 import eventstore.syntax._
 import eventstore.cluster._
 import eventstore.cluster.GossipSeedsOrDns.ClusterDns
 import eventstore.cluster.NodeState._
 import ClusterDiscovererActor._
 
-class ClusterDiscovererActorSpec extends ActorSpec with Mockito {
+class ClusterDiscovererActorSpec extends ActorSpec {
   "ClusterDiscovererActor" should {
     "discover cluster from dns" in new TestScope {
       actor ! GetAddress()

--- a/client/src/test/scala/eventstore/akka/streams/AllStreamsSourceSpec.scala
+++ b/client/src/test/scala/eventstore/akka/streams/AllStreamsSourceSpec.scala
@@ -463,7 +463,7 @@ class AllStreamsSourceSpec extends SourceSpec {
     ///
 
     def newEvent(x: Long) =
-      IndexedEvent(mock[Event], Position.Exact(x))
+      IndexedEvent(TestData.eventRecord, Position.Exact(x))
 
     def readEvents(x: Long) =
       ReadAllEvents(Position(x), readBatchSize, Forward, resolveLinkTos = resolveLinkTos)

--- a/client/src/test/scala/eventstore/akka/streams/SourceSpec.scala
+++ b/client/src/test/scala/eventstore/akka/streams/SourceSpec.scala
@@ -8,9 +8,8 @@ import _root_.akka.stream.ActorMaterializer
 import _root_.akka.stream.scaladsl._
 import _root_.akka.stream.testkit.scaladsl._
 import _root_.akka.testkit._
-import org.specs2.mock.Mockito
 
-abstract class SourceSpec extends ActorSpec with Mockito {
+abstract class SourceSpec extends ActorSpec {
 
   abstract class AbstractSourceScope[T] extends ActorScope {
 

--- a/client/src/test/scala/eventstore/akka/streams/StreamSourceSpec.scala
+++ b/client/src/test/scala/eventstore/akka/streams/StreamSourceSpec.scala
@@ -512,7 +512,7 @@ class StreamSourceSpec extends SourceSpec {
       ))
 
     def newEvent(number: Long): Event =
-      EventRecord(streamId, EventNumber.Exact(number), mock[EventData])
+      EventRecord(streamId, EventNumber.Exact(number), TestData.eventData)
 
     def readEvents(x: Long) =
       ReadStreamEvents(streamId, EventNumber(x), readBatchSize, Forward, resolveLinkTos = resolveLinkTos)
@@ -520,7 +520,7 @@ class StreamSourceSpec extends SourceSpec {
     def readCompleted(next: Long, endOfStream: Boolean, events: Event*) = ReadStreamEventsCompleted(
       events = events.toList,
       nextEventNumber = EventNumber(next),
-      lastEventNumber = mock[EventNumber.Exact],
+      lastEventNumber = EventNumber.Exact(1L),
       endOfStream = endOfStream,
       lastCommitPosition = next.toLong,
       direction = Forward

--- a/client/src/test/scala/eventstore/akka/tcp/ConnectionActorSpec.scala
+++ b/client/src/test/scala/eventstore/akka/tcp/ConnectionActorSpec.scala
@@ -9,7 +9,6 @@ import _root_.akka.actor.{ActorRef, Status, Terminated}
 import _root_.akka.io.{IO, Tcp}
 import _root_.akka.testkit.{TestActorRef, TestProbe}
 import _root_.akka.stream.StreamTcpException
-import org.specs2.mock.Mockito
 import NotHandled.{MasterInfo, NotMaster}
 import eventstore.syntax._
 import eventstore.tcp._
@@ -19,7 +18,7 @@ import eventstore.akka.ActorSpec
 import eventstore.akka.cluster.ClusterDiscovererActor.{Address, GetAddress}
 import eventstore.akka.tcp.ConnectionActor.Disconnected
 
-class ConnectionActorSpec extends ActorSpec with Mockito {
+class ConnectionActorSpec extends ActorSpec {
 
   val off = 1.minute
 
@@ -889,7 +888,7 @@ class ConnectionActorSpec extends ActorSpec with Mockito {
       verifyReconnections(n - 1)
     }
 
-    final case class Connect(address: InetSocketAddress)
+    case class Connect(address: InetSocketAddress)
   }
 
   trait OperationTimedOutScope extends TestScope {

--- a/core/src/main/scala/eventstore/tcp/TypeAliases.scala
+++ b/core/src/main/scala/eventstore/tcp/TypeAliases.scala
@@ -1,0 +1,12 @@
+package eventstore
+package tcp
+
+// TODO(AHJ): Restore this into package object after 7.1.0
+
+private[eventstore] trait TypeAliases {
+
+  type Bytes      = Array[Byte]
+  type Flags      = Byte
+  type Flag       = Byte
+  type MarkerByte = Byte
+}

--- a/core/src/main/scala/eventstore/tcp/package.scala
+++ b/core/src/main/scala/eventstore/tcp/package.scala
@@ -1,8 +1,3 @@
 package eventstore
 
-package object tcp {
-  type Bytes      = Array[Byte]
-  type Flags      = Byte
-  type Flag       = Byte
-  type MarkerByte = Byte
-}
+package object tcp extends TypeAliases

--- a/core/src/main/scala/eventstore/util/IntToByteVector.scala
+++ b/core/src/main/scala/eventstore/util/IntToByteVector.scala
@@ -7,7 +7,7 @@ import eventstore.syntax.Attempt
 // This code is inspired by scodec's `IntCodec`, see:
 // https://github.com/scodec/scodec/blob/series/1.11.x/shared/src/main/scala/scodec/codecs/IntCodec.scala
 
-private[eventstore]final class IntToByteVector(bits: Int, signed: Boolean, ordering: ByteOrdering) {
+private[eventstore] final class IntToByteVector(bits: Int, signed: Boolean, ordering: ByteOrdering) {
 
   require(bits > 0 && bits <= (if (signed) 32 else 31),
     "bits must be in range [1, 32] for signed and [1, 31] for unsigned"

--- a/core/src/test/scala/eventstore/MessageSpec.scala
+++ b/core/src/test/scala/eventstore/MessageSpec.scala
@@ -1,12 +1,12 @@
 package eventstore
 
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import eventstore.constants.MaxBatchSize
 import eventstore.util.uuid.randomUuid
 import PersistentSubscription._
+import TestData.{eventRecord, indexedEvent}
 
-class MessageSpec extends Specification with Mockito {
+class MessageSpec extends Specification {
 
   "TransactionStartCompleted" should {
 
@@ -73,8 +73,7 @@ class MessageSpec extends Specification with Mockito {
     }
 
     "throw exception if events.size > MaxBatchSize" in {
-      val event = mock[Event]
-      val events = List.fill(MaxBatchSize + 1)(event)
+      val events = List.fill(MaxBatchSize + 1)(eventRecord)
       ReadStreamEventsCompleted(events, EventNumber.Exact(1), EventNumber.Exact(0), endOfStream = false, 0,
         ReadDirection.Forward) must throwAn[IllegalArgumentException]
     }
@@ -94,8 +93,7 @@ class MessageSpec extends Specification with Mockito {
   "ReadAllEventsCompleted" should {
 
     "throw exception if events.size > MaxBatchSize" in {
-      val event = mock[IndexedEvent]
-      val events = List.fill(MaxBatchSize + 1)(event)
+      val events = List.fill(MaxBatchSize + 1)(indexedEvent)
       val position = Position.Exact(1)
       ReadAllEventsCompleted(events, position, position, ReadDirection.Forward) must throwAn[IllegalArgumentException]
     }

--- a/core/src/test/scala/eventstore/TestData.scala
+++ b/core/src/test/scala/eventstore/TestData.scala
@@ -1,0 +1,50 @@
+package eventstore
+
+import eventstore.util.uuid.randomUuid
+import eventstore.{PersistentSubscription ⇒ Ps}
+
+object TestData {
+
+  val streamId: EventStream.Id              = EventStream.Id("test")
+  val expectedAny: ExpectedVersion.Existing = ExpectedVersion.Any
+  val requireMaster: Boolean                = true
+  val psGroup: String                       = "test-group"
+  val hardDelete: Boolean                   = true
+  val exactN: EventNumber.Exact             = EventNumber.First
+  val exactP: Position.Exact                = Position.First
+  val readDirection: ReadDirection          = ReadDirection.Forward
+  val eventData: EventData                  = EventData("type", randomUuid, Content.Empty, Content.Empty)
+  val eventRecord: EventRecord              = EventRecord(streamId, exactN, eventData)
+  val indexedEvent: IndexedEvent            = IndexedEvent(eventRecord, Position.First)
+
+  def psCreate: Ps.Create = Ps.Create(streamId, psGroup)
+  def psUpdate: Ps.Update = Ps.Update(streamId, psGroup)
+  def psDelete: Ps.Delete = Ps.Delete(streamId, psGroup)
+
+  def writeEventsCompleted: WriteEventsCompleted = WriteEventsCompleted(None, None)
+  def writeEvents: WriteEvents = WriteEvents(streamId, Nil, expectedAny, requireMaster)
+
+  def deleteStream: DeleteStream = DeleteStream(streamId, expectedAny, hardDelete, requireMaster)
+  def deleteStreamCompleted: DeleteStreamCompleted = DeleteStreamCompleted(None)
+
+  def readEvent: ReadEvent = ReadEvent(streamId)
+  def readEventCompleted: ReadEventCompleted = ReadEventCompleted(eventRecord)
+
+  def readStreamEvents: ReadStreamEvents = ReadStreamEvents(streamId)
+  def readStreamEventsCompleted: ReadStreamEventsCompleted = ReadStreamEventsCompleted(Nil, exactN, exactN, true, 1L, readDirection)
+
+  def readAllEvents: ReadAllEvents = ReadAllEvents(exactP)
+  def readAllEventsCompleted: ReadAllEventsCompleted = ReadAllEventsCompleted(Nil, exactP, exactP, readDirection)
+
+  def scavengeDatabaseResponse: ScavengeDatabaseResponse = ScavengeDatabaseResponse(None)
+
+  def transactionCommit: TransactionCommit = TransactionCommit(1L, requireMaster)
+  def transactionCommitCompleted: TransactionCommitCompleted = TransactionCommitCompleted(1L)
+
+  def transactionStart: TransactionStart = TransactionStart(streamId, expectedAny, requireMaster)
+  def transactionStartCompleted: TransactionStartCompleted = TransactionStartCompleted(1L)
+
+  def transactionWrite: TransactionWrite = TransactionWrite(1L, Nil, requireMaster)
+  def transactionWriteCompleted: TransactionWriteCompleted = TransactionWriteCompleted(1L)
+
+}

--- a/core/src/test/scala/eventstore/operations/CreatePersistentSubscriptionInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/CreatePersistentSubscriptionInspectionSpec.scala
@@ -3,13 +3,13 @@ package operations
 
 import scala.util.{ Failure, Success }
 import org.specs2.mutable.Specification
-import org.specs2.mock.Mockito
 import CreatePersistentSubscriptionError._
-import PersistentSubscription.{Create, CreateCompleted}
+import PersistentSubscription.CreateCompleted
 import Inspection.Decision._
+import TestData._
 
-class CreatePersistentSubscriptionInspectionSpec extends Specification with Mockito {
-  val inspection = CreatePersistentSubscriptionInspection(mock[Create]).pf
+class CreatePersistentSubscriptionInspectionSpec extends Specification {
+  val inspection = CreatePersistentSubscriptionInspection(psCreate).pf
 
   "CreatePersistentSubscriptionInspection" should {
 

--- a/core/src/test/scala/eventstore/operations/DeletePersistentSubscriptionInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/DeletePersistentSubscriptionInspectionSpec.scala
@@ -3,13 +3,13 @@ package operations
 
 import scala.util.{ Failure, Success }
 import org.specs2.mutable.Specification
-import org.specs2.mock.Mockito
 import DeletePersistentSubscriptionError._
-import PersistentSubscription.{Delete, DeleteCompleted}
+import PersistentSubscription.DeleteCompleted
 import Inspection.Decision._
+import TestData._
 
-class DeletePersistentSubscriptionInspectionSpec extends Specification with Mockito {
-  val inspection = DeletePersistentSubscriptionInspection(mock[Delete]).pf
+class DeletePersistentSubscriptionInspectionSpec extends Specification {
+  val inspection = DeletePersistentSubscriptionInspection(psDelete).pf
 
   "DeletePersistentSubscriptionInspection" should {
 

--- a/core/src/test/scala/eventstore/operations/DeleteStreamInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/DeleteStreamInspectionSpec.scala
@@ -2,18 +2,18 @@ package eventstore
 package operations
 
 import scala.util.{ Failure, Success }
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import OperationError._
 import Inspection.Decision.{Retry, Stop, Fail}
+import TestData._
 
-class DeleteStreamInspectionSpec extends Specification with Mockito {
-  val inspection = DeleteStreamInspection(mock[DeleteStream]).pf
+class DeleteStreamInspectionSpec extends Specification {
+  val inspection = DeleteStreamInspection(deleteStream).pf
 
   "DeleteStreamInspection" should {
 
     "handle DeleteStreamCompleted" in {
-      inspection(Success(mock[DeleteStreamCompleted])) mustEqual Stop
+      inspection(Success(deleteStreamCompleted)) mustEqual Stop
     }
 
     "handle PrepareTimeout" in {

--- a/core/src/test/scala/eventstore/operations/ReadAllEventsInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/ReadAllEventsInspectionSpec.scala
@@ -2,18 +2,18 @@ package eventstore
 package operations
 
 import scala.util.{ Failure, Success }
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import ReadAllEventsError._
 import Inspection.Decision.{Stop, Fail}
+import TestData._
 
-class ReadAllEventsInspectionSpec extends Specification with Mockito {
-  val inspection = ReadAllEventsInspection(mock[ReadAllEvents]).pf
+class ReadAllEventsInspectionSpec extends Specification {
+  val inspection = ReadAllEventsInspection(readAllEvents).pf
 
   "ReadAllEventsInspection" should {
 
     "handle ReadAllEventsCompleted" in {
-      inspection(Success(mock[ReadAllEventsCompleted])) mustEqual Stop
+      inspection(Success(readAllEventsCompleted)) mustEqual Stop
     }
 
     "handle Error" in {

--- a/core/src/test/scala/eventstore/operations/ReadEventInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/ReadEventInspectionSpec.scala
@@ -2,18 +2,18 @@ package eventstore
 package operations
 
 import scala.util.{ Failure, Success }
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import ReadEventError._
 import Inspection.Decision.{Stop, Fail}
+import TestData._
 
-class ReadEventInspectionSpec extends Specification with Mockito {
-  val inspection = ReadEventInspection(ReadEvent(EventStream.Id("test"))).pf
+class ReadEventInspectionSpec extends Specification {
+  val inspection = ReadEventInspection(readEvent).pf
 
   "ReadEventInspection" should {
 
     "handle ReadEventCompleted" in {
-      inspection(Success(ReadEventCompleted(mock[Event]))) mustEqual Stop
+      inspection(Success(readEventCompleted)) mustEqual Stop
     }
 
     "handle StreamNotFound" in {

--- a/core/src/test/scala/eventstore/operations/ReadStreamEventsInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/ReadStreamEventsInspectionSpec.scala
@@ -2,18 +2,19 @@ package eventstore
 package operations
 
 import scala.util.{ Failure, Success }
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import ReadStreamEventsError._
 import Inspection.Decision.{Stop, Fail}
+import TestData._
 
-class ReadStreamEventsInspectionSpec extends Specification with Mockito {
-  val inspection = ReadStreamEventsInspection(mock[ReadStreamEvents]).pf
+class ReadStreamEventsInspectionSpec extends Specification {
+
+  val inspection = ReadStreamEventsInspection(readStreamEvents).pf
 
   "ReadStreamEventsInspection" should {
 
     "handle ReadStreamEventsCompleted" in {
-      inspection(Success(mock[ReadStreamEventsCompleted])) mustEqual Stop
+      inspection(Success(readStreamEventsCompleted)) mustEqual Stop
     }
 
     "handle StreamNotFound" in {

--- a/core/src/test/scala/eventstore/operations/ScavengeDatabaseInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/ScavengeDatabaseInspectionSpec.scala
@@ -2,18 +2,18 @@ package eventstore
 package operations
 
 import scala.util.{ Failure, Success }
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import ScavengeError.{InProgress, Unauthorized}
 import Inspection.Decision.{Fail, Stop}
+import TestData._
 
-class ScavengeDatabaseInspectionSpec extends Specification with Mockito {
+class ScavengeDatabaseInspectionSpec extends Specification {
   val inspection = ScavengeDatabaseInspection.pf
 
   "ScavengeDatabaseInspection" should {
 
     "handle ScavengeDatabaseCompleted" in {
-      inspection(Success(mock[ScavengeDatabaseResponse])) mustEqual Stop
+      inspection(Success(scavengeDatabaseResponse)) mustEqual Stop
     }
 
     "handle InProgress" in {

--- a/core/src/test/scala/eventstore/operations/SimpleInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/SimpleInspectionSpec.scala
@@ -2,14 +2,13 @@ package eventstore
 package operations
 
 import scala.util.Success
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import Inspection.Decision._
 
-class SimpleInspectionSpec extends Specification with Mockito {
+class SimpleInspectionSpec extends Specification {
   "SimpleInspection" should {
     "handle provided value only" in {
-      val in = mock[In]
+      val in = ClientIdentified
       val inspection = new SimpleInspection(in).pf
       inspection(Success(in)) mustEqual Stop
     }

--- a/core/src/test/scala/eventstore/operations/TransactionCommitInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/TransactionCommitInspectionSpec.scala
@@ -2,18 +2,18 @@ package eventstore
 package operations
 
 import scala.util.{ Failure, Success }
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import Inspection.Decision.{Retry, Stop, Fail}
 import OperationError._
+import TestData._
 
-class TransactionCommitInspectionSpec extends Specification with Mockito {
-  val inspection = TransactionCommitInspection(mock[TransactionCommit]).pf
+class TransactionCommitInspectionSpec extends Specification {
+  val inspection = TransactionCommitInspection(transactionCommit).pf
 
   "TransactionCommitInspection" should {
 
     "handle TransactionCommitCompleted" in {
-      inspection(Success(mock[TransactionCommitCompleted])) mustEqual Stop
+      inspection(Success(transactionCommitCompleted)) mustEqual Stop
     }
 
     "handle PrepareTimeout" in {

--- a/core/src/test/scala/eventstore/operations/TransactionStartInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/TransactionStartInspectionSpec.scala
@@ -2,18 +2,18 @@ package eventstore
 package operations
 
 import scala.util.{ Failure, Success }
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import OperationError._
 import Inspection.Decision.{Retry, Stop, Fail}
+import TestData._
 
-class TransactionStartInspectionSpec extends Specification with Mockito {
-  val inspection = TransactionStartInspection(mock[TransactionStart]).pf
+class TransactionStartInspectionSpec extends Specification {
+  val inspection = TransactionStartInspection(transactionStart).pf
 
   "TransactionStartInspection" should {
 
     "handle TransactionStartCompleted" in {
-      inspection(Success(mock[TransactionStartCompleted])) mustEqual Stop
+      inspection(Success(transactionStartCompleted)) mustEqual Stop
     }
 
     "handle CommitTimeout" in {

--- a/core/src/test/scala/eventstore/operations/TransactionWriteInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/TransactionWriteInspectionSpec.scala
@@ -2,18 +2,18 @@ package eventstore
 package operations
 
 import scala.util.{ Failure, Success }
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import OperationError._
 import Inspection.Decision.{Unexpected, Retry, Stop, Fail}
+import TestData._
 
-class TransactionWriteInspectionSpec extends Specification with Mockito {
-  val inspection = TransactionWriteInspection(mock[TransactionWrite]).pf
+class TransactionWriteInspectionSpec extends Specification {
+  val inspection = TransactionWriteInspection(transactionWrite).pf
 
   "TransactionStartInspection" should {
 
     "handle TransactionStartCompleted" in {
-      inspection(Success(mock[TransactionWriteCompleted])) mustEqual Stop
+      inspection(Success(transactionWriteCompleted)) mustEqual Stop
     }
 
     "handle CommitTimeout" in {

--- a/core/src/test/scala/eventstore/operations/UpdatePersistentSubscriptionInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/UpdatePersistentSubscriptionInspectionSpec.scala
@@ -3,13 +3,13 @@ package operations
 
 import scala.util.{ Failure, Success }
 import org.specs2.mutable.Specification
-import org.specs2.mock.Mockito
 import UpdatePersistentSubscriptionError._
-import PersistentSubscription.{Update, UpdateCompleted}
+import PersistentSubscription.UpdateCompleted
 import Inspection.Decision._
+import TestData._
 
-class UpdatePersistentSubscriptionInspectionSpec extends Specification with Mockito {
-  val inspection = UpdatePersistentSubscriptionInspection(mock[Update]).pf
+class UpdatePersistentSubscriptionInspectionSpec extends Specification {
+  val inspection = UpdatePersistentSubscriptionInspection(psUpdate).pf
 
   "UpdatePersistentSubscriptionInspection" should {
 

--- a/core/src/test/scala/eventstore/operations/WriteEventsInspectionSpec.scala
+++ b/core/src/test/scala/eventstore/operations/WriteEventsInspectionSpec.scala
@@ -2,18 +2,18 @@ package eventstore
 package operations
 
 import scala.util.{ Failure, Success }
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import OperationError._
 import Inspection.Decision.{Stop, Retry, Fail}
+import TestData._
 
-class WriteEventsInspectionSpec extends Specification with Mockito {
-  val inspection = WriteEventsInspection(mock[WriteEvents]).pf
+class WriteEventsInspectionSpec extends Specification {
+  val inspection = WriteEventsInspection(writeEvents).pf
 
   "WriteEventsInspection" should {
 
     "handle WriteEventsCompleted" in {
-      inspection(Success(mock[WriteEventsCompleted])) mustEqual Stop
+      inspection(Success(writeEventsCompleted)) mustEqual Stop
     }
 
     "handle PrepareTimeout" in {


### PR DESCRIPTION
 - change various implementations in akka to
   `private[eventstore]` in order to minimize
   the public surface area.

 - add missing Java API's that deprecations point
   to.

 - rename some local variables due to shadowing
   warnings.

 - delete some of the deprecated methods that have
   had replacements for a long time.

 - temporary add tcp package object to client project
   in order to reduce client breakage and rather use
   deprecation warnings.

 - mark all case classes as final.

 - fix usage of mockito wrt. mock not working with
   final classes.

 - add `TestData` in core and client in order to
   eliminate `mock` usage.

 - change `StashEntry` to be part of companion of
   `TransactionActor` due to `final case class`
   results in outer reference warning.