### PR TITLE
misc: rm mockito / deps / fatal warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val commonSettings = Seq(
     "-feature",
     "-unchecked",
     "-deprecation",
-  //  "-Xfatal-warnings",
+    "-Xfatal-warnings",
     "-Xlint:-missing-interpolator",
     "-Yno-adapted-args",
     "-Ywarn-dead-code",
@@ -68,19 +68,15 @@ lazy val core = project
   .settings(commonSettings)
   .settings(
     moduleName := "eventstore-client-core",
-    version in ProtobufConfig := "3.0.0",
-    protobufRunProtoc in ProtobufConfig := { args => Protoc.runProtoc("-v3.0.0" +: args.toArray) },
+    version in ProtobufConfig := protobufVersion,
+    protobufRunProtoc in ProtobufConfig := { args => Protoc.runProtoc(s"-v$protobufVersion" +: args.toArray) },
     coverageExcludedPackages :=
       "eventstore.proto;" +
       "eventstore.tcp.EventStoreProtoFormats;" +
-      "eventstore.tcp.MarkerBytes;" +
-      "eventstore.util.ToCoarsest"
+      "eventstore.tcp.MarkerBytes;"
   ).settings(
-    libraryDependencies ++= Seq(
-      `scodec-bits`, `ts-config`
-    ) ++ testDeps(
-      `mockito-all`, Specs2.core, Specs2.mock
-    )
+    libraryDependencies ++=
+      Seq(`scodec-bits`, `ts-config`) ++ testDeps(specs2)
   )
   .enablePlugins(ProtobufPlugin)
 
@@ -103,7 +99,7 @@ lazy val client = project
       `ts-config`,`spray-json`, `scodec-bits`,
       Reactive.streams, Akka.actor, Akka.stream, AkkaHttp.http, AkkaHttp.`http-spray-json`
     ) ++ testDeps(
-        `mockito-all`, Specs2.core, Specs2.mock, Reactive.`streams-tck`, Akka.testkit, Akka.`stream-testkit`
+      specs2, Reactive.`streams-tck`, Akka.testkit, Akka.`stream-testkit`
     )
   )
   .dependsOn(core)

--- a/client/src/main/scala/eventstore/akka/tcp/BidiLogging.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/BidiLogging.scala
@@ -14,18 +14,16 @@ private[eventstore] object BidiLogging {
 
     def logPackIn(packIn: PackIn): PackIn = {
       if (log.isDebugEnabled) packIn.message match {
-        case Success(HeartbeatRequest) =>
-        case Success(Ping)             =>
-        case _                         => log.debug(packIn.toString)
+        case Success(HeartbeatRequest | Ping) =>
+        case _                                => log.debug(packIn.toString)
       }
       packIn
     }
 
     def logPackOut(packOut: PackOut): PackOut = {
       if (log.isDebugEnabled) packOut.message match {
-        case HeartbeatResponse =>
-        case Pong              =>
-        case _                 => log.debug(packOut.toString)
+        case HeartbeatResponse | Pong =>
+        case _                        => log.debug(packOut.toString)
       }
       packOut
     }

--- a/client/src/test/scala/eventstore/akka/EventStoreExtensionSpec.scala
+++ b/client/src/test/scala/eventstore/akka/EventStoreExtensionSpec.scala
@@ -2,21 +2,21 @@ package eventstore
 package akka
 
 import _root_.akka.actor.Status.Failure
-import scala.concurrent.Await
-import scala.concurrent.duration._
+import _root_.akka.pattern.AskTimeoutException
 
 class EventStoreExtensionSpec extends ActorSpec {
+
+  val extension = EventStoreExtension(system)
   val readEvent = ReadEvent(EventStream.Id(randomUuid.toString))
 
   "EventStoreExtension" should {
     "return connection actor" in new ActorScope {
-      EventStoreExtension(system).actor ! readEvent
+      extension.actor ! readEvent
       expectMsgPF() { case Failure(_: EsException) => }
     }
 
-    "return connection instance" in new ActorScope {
-      val future = EventStoreExtension(system).connection(readEvent)
-      Await.result(future, 3.seconds) must throwAn[EsException]
+    "return connection instance" in {
+      extension.connection(readEvent).await_ must throwAn[EsException] or throwAn[AskTimeoutException]
     }
   }
 }

--- a/client/src/test/scala/eventstore/akka/tcp/BidiLoggingSpec.scala
+++ b/client/src/test/scala/eventstore/akka/tcp/BidiLoggingSpec.scala
@@ -3,14 +3,14 @@ package akka
 package tcp
 
 import scala.util.Success
-import org.specs2.mock.Mockito
-import _root_.akka.event.LoggingAdapter
+import scala.collection.mutable.{Queue => MQueue}
 import _root_.akka.stream.scaladsl._
 import _root_.akka.stream.{ActorMaterializer, OverflowStrategy}
 import _root_.akka.testkit.TestProbe
 import eventstore.tcp.{PackIn, PackOut}
+import testutil.TestLogger
 
-class BidiLoggingSpec extends ActorSpec with Mockito {
+class BidiLoggingSpec extends ActorSpec {
 
   implicit val materializer = ActorMaterializer()
 
@@ -19,42 +19,53 @@ class BidiLoggingSpec extends ActorSpec with Mockito {
     "log incoming & outgoing if enabled" in new TestScope {
       val packIn = PackIn(Authenticated)
       val packOut = PackOut(Authenticate, packIn.correlationId)
+
       source ! packIn
       sink.expectMsg(packOut)
-      there was one(log).debug(packIn.toString)
-      there was one(log).debug(packOut.toString)
+
+      debugLog    shouldEqual List(packIn.toString, packOut.toString)
+      debugChecks shouldEqual 4 // Same check happens inside debug call, hence 4 instead of 2.
     }
 
     "not log incoming & outgoing if disabled" in new TestScope {
-      log.isDebugEnabled returns false
+      override def turnOffLogging = true
       source ! PackIn(Authenticated)
       sink.expectMsgType[PackOut].message shouldEqual Authenticate
-      there was two(log).isDebugEnabled
-      there were noMoreCallsTo(log)
+      debugLog.size shouldEqual 0
+      debugChecks   shouldEqual 2
     }
 
     "not log Pong & Ping" in new TestScope {
       source ! PackIn(Ping)
       sink.expectMsgType[PackOut].message shouldEqual Pong
-      there was two(log).isDebugEnabled
-      there were noMoreCallsTo(log)
+      debugLog.size shouldEqual 0
+      debugChecks   shouldEqual 2
     }
 
     "not log HeartbeatRequest & HeartbeatResponse" in new TestScope {
       source ! PackIn(HeartbeatRequest)
       sink.expectMsgType[PackOut].message shouldEqual HeartbeatResponse
-      there was two(log).isDebugEnabled
-      there were noMoreCallsTo(log)
+      debugLog.size shouldEqual 0
+      debugChecks   shouldEqual 2
     }
   }
 
   private trait TestScope extends ActorScope {
-    val log = {
-      val log = mock[LoggingAdapter]
-      log.isDebugEnabled returns true
-      log
-    }
-    val logging = BidiLogging(log)
+
+    import TestLogger.Item
+
+    def turnOffLogging: Boolean = false
+
+    private var dc  = 0
+    private val ls  = MQueue.empty[Item.Debug]
+    private val log = TestLogger.debug(ls.enqueue(_), { dc = dc + 1 })
+
+    final def debugChecks: Int       = dc
+    final def debugLog: List[String] = ls.toList.map(_.msg)
+
+    private def logAdapter = if(turnOffLogging) log.turnOff else log
+
+    val logging = BidiLogging(logAdapter)
     val sink = TestProbe()
     val flow = Flow.fromFunction[PackIn, PackOut] {
       case PackIn(Success(Ping), correlationId)             => PackOut(Pong, correlationId)

--- a/client/src/test/scala/eventstore/akka/testutil/TestLogger.scala
+++ b/client/src/test/scala/eventstore/akka/testutil/TestLogger.scala
@@ -1,0 +1,63 @@
+package eventstore
+package akka
+package testutil
+
+import scala.reflect.{ClassTag => CT}
+import _root_.akka.event.LoggingAdapter
+import TestLogger.Item
+import TestLogger.Level
+
+final case class TestLogger private(
+  debug: Boolean            = false,
+  info: Boolean             = false,
+  warning: Boolean          = false,
+  error: Boolean            = false,
+  itemSink: Item => Unit    = _ => (),
+  levelCheck: Level => Unit = _ => ()
+) extends LoggingAdapter {
+
+  def isDebugEnabled: Boolean   = { levelCheck(Level.Debug);   debug   }
+  def isInfoEnabled: Boolean    = { levelCheck(Level.Info);    info    }
+  def isWarningEnabled: Boolean = { levelCheck(Level.Warning); warning }
+  def isErrorEnabled: Boolean   = { levelCheck(Level.Error);   error   }
+
+  def notifyDebug(message: String): Unit                   = itemSink(Item.Debug(message))
+  def notifyInfo(message: String): Unit                    = itemSink(Item.Info(message))
+  def notifyWarning(message: String): Unit                 = itemSink(Item.Warning(message))
+  def notifyError(message: String): Unit                   = itemSink(Item.Error(message, None))
+  def notifyError(cause: Throwable, message: String): Unit = itemSink(Item.Error(message, Some(cause)))
+
+  def turnOff: TestLogger =
+    TestLogger(itemSink = itemSink, levelCheck = levelCheck)
+}
+
+object TestLogger {
+
+  sealed trait Level
+  object Level {
+    case object Debug   extends Level
+    case object Info    extends Level
+    case object Warning extends Level
+    case object Error   extends Level
+  }
+
+  sealed abstract class Item(val level: Level) {
+    val msg: String
+  }
+
+  object Item {
+    final case class Debug(msg: String)                        extends Item(Level.Debug)
+    final case class Info(msg: String)                         extends Item(Level.Info)
+    final case class Warning(msg: String)                      extends Item(Level.Warning)
+    final case class Error(msg: String, th: Option[Throwable]) extends Item(Level.Error)
+  }
+
+  def debug(onDebug: Item.Debug => Unit, onDebugCheck: => Unit): TestLogger = TestLogger(
+    debug      = true,
+    itemSink   = only[Item.Debug, Item](onDebug),
+    levelCheck = only[Level.Debug.type, Level](_ => onDebugCheck)
+  )
+
+  private def only[T: CT, R](cb: T => Unit): R => Unit = { case d: T => cb(d); case _ => () }
+
+}

--- a/core/src/test/scala/eventstore/operations/RetryableOperationSpec.scala
+++ b/core/src/test/scala/eventstore/operations/RetryableOperationSpec.scala
@@ -2,89 +2,87 @@ package eventstore
 package operations
 
 import scala.util.control.NoStackTrace
-import scala.util.{ Try, Random, Failure }
-import org.specs2.mock.Mockito
+import scala.util.{Failure, Random, Try}
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import eventstore.tcp.PackOut
 import eventstore.util.uuid.randomUuid
 import OnIncoming._
 
-class RetryableOperationSpec extends Specification with Mockito {
+class RetryableOperationSpec extends Specification {
 
   "RetryableOperation" should {
 
     "proxy id" in new TestScope {
       operation.id mustEqual operation.operation.id
-      there was two(underlying).id
     }
 
     "proxy client" in new TestScope {
       operation.client mustEqual operation.operation.client
-      there was two(underlying).client
     }
 
     "proxy version" in new TestScope {
       operation.version mustEqual operation.operation.version
-      there was two(underlying).version
     }
 
     "wrap underlying connected result if Retry" in new TestScope {
-      val result = mock[OP]
-      underlying.connected returns OnConnected.Retry(result, pack)
-      val expected = operation.copy(operation = result)
-      operation.copy(ongoing = false).connected mustEqual OnConnected.Retry(expected, pack)
+
+      val expected    = operation.copy(operation = DefaultOp)
+      val underlyingM = underlying.copy(connected = OnConnected.Retry(DefaultOp, packOut))
+      val operationM  = operation.copy(ongoing = false, operation = underlyingM)
+
+      operationM.connected mustEqual OnConnected.Retry(expected, packOut)
     }
 
     "return underlying connected result if Stop" in new TestScope {
       operation.copy(ongoing = false).connected mustEqual OnConnected.Stop(in)
-      there was one(underlying).connected
     }
 
     "proxy clientTerminated" in new TestScope {
-      operation.clientTerminated mustEqual underlying.clientTerminated
-      there was two(underlying).clientTerminated
+
+      val underlyingM = underlying.copy(clientTerminated = Some(packOut))
+      val operationM  = operation.copy(operation = underlyingM)
+
+      operationM.clientTerminated must beSome(packOut)
     }
 
     "wrap underlying on disconnected result if Continue" in new TestScope {
-      val result = mock[OP]
-      underlying.disconnected returns OnDisconnected.Continue(result)
-      operation.disconnected mustEqual OnDisconnected.Continue(operation.copy(operation = result, ongoing = false))
-      there was one(underlying).disconnected
+
+      val expected    = OnDisconnected.Continue(operation.copy(operation = DefaultOp, ongoing = false))
+      val underlyingM = underlying.copy(disconnected = OnDisconnected.Continue(DefaultOp))
+      val operationM  = operation.copy(operation = underlyingM)
+
+      operationM.disconnected mustEqual expected
     }
 
     "return underlying on disconnected result if Stop" in new TestScope {
       operation.disconnected mustEqual OnDisconnected.Stop(in)
-      there was one(underlying).disconnected
     }
 
     "wrap underlying inspectOut result if Some" in new TestScope {
-      val result = mock[OP]
-      val pf: PartialFunction[Out, OnOutgoing[OP]] = {
-        case `out` => OnOutgoing.Continue(result, pack)
-      }
-      underlying.inspectOut returns pf
-      operation.inspectOut(out) mustEqual OnOutgoing.Continue(result, pack)
-      there was one(underlying).inspectOut
+
+      val underlyingM = underlying.copy(inspectOut = { case `out` => OnOutgoing.Continue(DefaultOp, packOut) })
+      val operationM  = operation.copy(operation = underlyingM)
+
+      operationM.inspectOut(out) mustEqual OnOutgoing.Continue(DefaultOp, packOut)
     }
 
     "return underlying inspectOut result if None" in new TestScope {
       operation.inspectOut.lift(out) must beNone
-      there was one(underlying).inspectOut
-      there was one(inspectOut).isDefinedAt(out)
     }
   }
 
   "RetryableOperation.inspectIn" should {
+
     "retry and decrease retries left" in new TestScope {
       operation.inspectIn(forceRetry) must beLike {
-        case Retry(RetryableOperation(`underlying`, 0, 1, true), `pack`) => ok
+        case Retry(RetryableOperation(`underlying`, 0, 1, true), `packOut`) => ok
       }
     }
 
     "retry and not decrease retries left if disconnected" in new TestScope {
       operation.copy(ongoing = false).inspectIn(forceRetry) must beLike {
-        case Retry(RetryableOperation(`underlying`, 1, 1, false), `pack`) => ok
+        case Retry(RetryableOperation(`underlying`, 1, 1, false), `packOut`) => ok
       }
     }
 
@@ -106,35 +104,72 @@ class RetryableOperationSpec extends Specification with Mockito {
 
   private trait TestScope extends Scope {
 
-    type OP = Operation[Unit]
+    import RetryableOperationSpec._
 
-    val forceRetry = Failure(new TestException)
-    val forceContinue = Failure(new TestException)
-    val out = mock[Out]
-    val in = Try(Pong)
-    val pack = PackOut(out)
-    val inspectOut = spy(new InspectOut)
-    val underlying = {
-      val operation = mock[OP]
-      operation.clientTerminated returns None
-      operation.id returns randomUuid
-      operation.version returns Random.nextInt()
-      operation.connected returns OnConnected.Stop(in)
-      operation.disconnected returns OnDisconnected.Stop(in)
-      operation.inspectOut returns inspectOut
-      operation.inspectIn(forceRetry) returns OnIncoming.Retry(operation, pack)
-      operation.inspectIn(forceContinue) returns OnIncoming.Continue(operation, forceContinue)
-      operation
+    def maxRetries: Int     = 1
+
+    final val forceRetry    = Failure(new TestException)
+    final val forceContinue = Failure(new TestException)
+    final val id            = randomUuid
+    final val client        = 1
+    final val version       = Random.nextInt()
+    final val out           = Ping
+    final val in            = Try(Pong)
+    final val packOut       = PackOut(out)
+    final val disconnected  = OnDisconnected.Stop(in)
+    final val connected     = OnConnected.Stop(in)
+    final val terminated    = Option.empty[PackOut]
+    final val inspectOut    = InspectOut
+
+    final val inspectIn: OP => Try[In] => OnIncoming[OP] = op => {
+      case `forceRetry`    => OnIncoming.Retry[OP](op, packOut)
+      case `forceContinue` => OnIncoming.Continue(op, forceContinue)
+      case _               => OnIncoming.Ignore
     }
-    val operation = RetryableOperation(underlying, maxRetries, ongoing = true)
 
-    def maxRetries: Int = 1
-
-    class TestException extends Exception with NoStackTrace
+    final val DefaultOp  = DefaultOperation
+    final val underlying = TestOperation(client, id, version, inspectIn, inspectOut, connected, disconnected, terminated)
+    final val operation  = RetryableOperation(underlying, maxRetries, ongoing = true)
   }
 
-  class InspectOut extends PartialFunction[Out, OnOutgoing[Nothing]] {
+}
+
+object RetryableOperationSpec {
+
+  type Client = Int
+  type OP     = Operation[Client]
+
+  class TestException extends Exception with NoStackTrace
+
+  case object InspectOut extends PartialFunction[Out, OnOutgoing[Nothing]] {
     def isDefinedAt(x: Out) = false
     def apply(v1: Out) = sys.error("")
   }
+
+  final case class TestOperation[C](
+    client: C,
+    id: Uuid,
+    version: Int,
+    insIn: Operation[C] => Try[In] => OnIncoming[Operation[C]],
+    inspectOut: PartialFunction[Out, OnOutgoing[Operation[C]]],
+    connected: OnConnected[Operation[C]],
+    disconnected: OnDisconnected[Operation[C]],
+    clientTerminated: Option[PackOut]
+  ) extends Operation[C] {
+    def inspectIn(in: Try[In]): OnIncoming[Self] = insIn(this)(in)
+  }
+
+  ///
+
+  val DefaultOperation: Operation[Client] = TestOperation[Client](
+    client           = 1,
+    id               = randomUuid,
+    version          = Random.nextInt(),
+    insIn            = _ => _ => OnIncoming.Ignore,
+    inspectOut       = InspectOut,
+    connected        = OnConnected.Stop(Try(Ping)),
+    disconnected     = OnDisconnected.Stop(Try(Ping)),
+    clientTerminated = None
+  )
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,10 +2,12 @@ import sbt._
 
 object Dependencies {
 
+  val protobufVersion = "3.7.0"
+  
   val `ts-config`   = "com.typesafe" %  "config"      % "1.3.3"
   val `scodec-bits` = "org.scodec"   %% "scodec-bits" % "1.1.9"
   val `spray-json`  = "io.spray"     %% "spray-json"  % "1.3.5"
-  val `mockito-all` = "org.mockito"  %  "mockito-all" % "1.10.19"
+  val specs2        = "org.specs2"   %% "specs2-core" % "4.5.1"
 
   ///
 
@@ -21,12 +23,6 @@ object Dependencies {
     private val version = "10.1.7"
     val http              = "com.typesafe.akka" %% "akka-http"            % version
     val `http-spray-json` = "com.typesafe.akka" %% "akka-http-spray-json" % version
-  }
-
-  object Specs2 {
-    private val version = "3.8.6"
-    val core = "org.specs2" %% "specs2-core" % version
-    val mock = "org.specs2" %% "specs2-mock" % version
   }
 
   object Reactive {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,15 @@
-addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
+addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.4")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.5")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 
-libraryDependencies += "com.github.os72" % "protoc-jar" % "3.5.1.1"
+libraryDependencies += "com.github.os72" % "protoc-jar" % "3.7.0"


### PR DESCRIPTION
 - remove dependency on mockito from projects
   and adjust `RetryableOperationSpec` and
   `BidiLoggingSpec`.

 - enable `fatal-warnings` for `scalac`.

 - remove deprecated usage of `publisher` methods in
   `j/EsConnectionITest`

 - bump dependencies for sbt plugins and libraries.

 - add `TestLogger` that replaces mocking of
   `LoggingAdapter`. It is by no means complete and
   principled, but it solves the logging need of Akka.

 - fix ask timeout issue in `EventstoreExtensionSpec`.