### PR TITLE
all: scala 2.13 support + sbt syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: scala
 
 scala:
   - 2.12.8
+  - 2.13.0-M5
 
 sudo: required
 

--- a/client/src/main/scala/eventstore/akka/streams/SourceStageLogic.scala
+++ b/client/src/main/scala/eventstore/akka/streams/SourceStageLogic.scala
@@ -97,6 +97,7 @@ private[eventstore] abstract class SourceStageLogic[T, O <: Ordered[O], P <: O](
         rcvUnsubscribed(onUnsubscribeCompleted()) or
         rcvSubscribed(onSubscriptionCompleted)
     }
+    ()
   }
 
   def catchup(from: P, to: P, stash: Queue[T] = Queue.empty[T]): Unit = {
@@ -132,6 +133,7 @@ private[eventstore] abstract class SourceStageLogic[T, O <: Ordered[O], P <: O](
           rcvSubscribed(onResubscribed) or
           rcvUnsubscribed(onUnsubscribeCompleted())
       }
+      ()
     }
 
     readEventsFrom(from)
@@ -158,11 +160,13 @@ private[eventstore] abstract class SourceStageLogic[T, O <: Ordered[O], P <: O](
     state = newState
     emitMultiple(out, events.iterator, () ⇒ completeStage())
     stageActorBecome(ignoring)
+    ()
   }
 
   def waitUntilBufferAvailable(action: () ⇒ Unit): Unit = {
     state = state.copy(onBufferAvailable = Some(action))
     stageActorBecome(ignoring)
+    ()
   }
 
   def enqueueAndPush(events: T*): Unit = {

--- a/client/src/main/scala/eventstore/akka/tcp/Client.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/Client.scala
@@ -18,9 +18,9 @@ private[eventstore] final case class Client(private val ref: ActorRef) {
 
   def apply(in: Status.Failure)(implicit sender: ActorRef): Unit = ref ! in
 
-  def watch()(implicit context: ActorContext): Unit = context watch ref
+  def watch()(implicit context: ActorContext): Unit = { context watch ref; () }
 
-  def unwatch()(implicit context: ActorContext): Unit = context unwatch ref
+  def unwatch()(implicit context: ActorContext): Unit = { context unwatch ref; () }
 }
 
 private[eventstore] final case class Connection private (address: InetSocketAddress, private val ref: ActorRef) {
@@ -31,7 +31,7 @@ private[eventstore] final case class Connection private (address: InetSocketAddr
     system stop ref
   }
 
-  def unwatch()(implicit context: ActorContext): Unit = context unwatch ref
+  def unwatch()(implicit context: ActorContext): Unit = { context unwatch ref; () }
 
   def unapply(ref: ActorRef): Boolean = ref == this.ref
 }

--- a/client/src/main/scala/eventstore/akka/tcp/ConnectionActor.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/ConnectionActor.scala
@@ -355,6 +355,7 @@ private[eventstore] class ConnectionActor(settings: Settings) extends Actor with
     } else {
       log.debug("{} to {} in {}", label, address, in)
       system.scheduler.scheduleOnce(in, self, Connect(address))
+      ()
     }
   }
 

--- a/client/src/test/scala/eventstore/akka/ProjectionsClientITest.scala
+++ b/client/src/test/scala/eventstore/akka/ProjectionsClientITest.scala
@@ -69,7 +69,7 @@ class ProjectionsClientITest extends AbstractStreamsITest {
 
       EventuallyResults.eventually {
         val projectionDetails = client.fetchProjectionDetails(projectionName).await_(timeout)
-        projectionDetails.map(_.status) should beSome(Completed)
+        projectionDetails.map(_.status) shouldEqual Some(Completed)
       }
     }
 
@@ -83,7 +83,7 @@ class ProjectionsClientITest extends AbstractStreamsITest {
       } yield details
 
       val projectionDetails = result.await_(timeout)
-      projectionDetails.map(_.status) should beSome(Running)
+      projectionDetails.map(_.status) shouldEqual Some(Running)
     }
 
     "return the faulted status for a continuous projection that doesnt compile" in new TestScope {
@@ -97,7 +97,7 @@ class ProjectionsClientITest extends AbstractStreamsITest {
       } yield details
 
       val projectionDetails = result.await_(timeout)
-      projectionDetails.map(_.status) should beSome(Faulted)
+      projectionDetails.map(_.status) shouldEqual Some(Faulted)
     }
 
     "return None when fetching the project details of a non existant projection" in new TestScope {
@@ -135,7 +135,7 @@ class ProjectionsClientITest extends AbstractStreamsITest {
       client.createProjection(projectionName, ProjectionCodeWithNoState, OneTime)
 
       EventuallyResults.eventually {
-        val projectionCompleted = client.fetchProjectionDetails(projectionName).await_(timeout).map(_.status) should beSome(Completed)
+        val projectionCompleted = client.fetchProjectionDetails(projectionName).await_(timeout).map(_.status) shouldEqual Some(Completed)
         val resultIsEmpty = client.fetchProjectionState(projectionName).await_(timeout) shouldEqual Some("{}")
 
         projectionCompleted and resultIsEmpty
@@ -170,7 +170,7 @@ class ProjectionsClientITest extends AbstractStreamsITest {
       client.createProjection(projectionName, ProjectionCodeWithNoState, OneTime)
 
       EventuallyResults.eventually {
-        val projectionCompleted = client.fetchProjectionDetails(projectionName).await_(timeout).map(_.status) should beSome(Completed)
+        val projectionCompleted = client.fetchProjectionDetails(projectionName).await_(timeout).map(_.status) shouldEqual Some(Completed)
         val resultIsEmpty = client.fetchProjectionResult(projectionName).await_(timeout) shouldEqual Some("{}")
 
         projectionCompleted and resultIsEmpty
@@ -188,7 +188,7 @@ class ProjectionsClientITest extends AbstractStreamsITest {
       } yield status
 
       val projectionDetails = result.await_(timeout)
-      projectionDetails.map(_.status) should beSome(Stopped)
+      projectionDetails.map(_.status) shouldEqual Some(Stopped)
     }
 
     "restart a stopped projection" in new TestScope {
@@ -203,7 +203,7 @@ class ProjectionsClientITest extends AbstractStreamsITest {
       } yield status
 
       val projectionDetails = result.await_(timeout)
-      projectionDetails.map(_.status) should beSome(Running)
+      projectionDetails.map(_.status) shouldEqual Some(Running)
     }
 
     "delete a completed onetime projection" in new TestScope {
@@ -214,7 +214,7 @@ class ProjectionsClientITest extends AbstractStreamsITest {
         _ <- client.createProjection(projectionName, ProjectionCode, OneTime)
         _ <- waitForProjectionStatus(client, projectionName, Completed)
         _ <- client.stopProjection(projectionName)
-        stopped <- waitForProjectionStatus(client, projectionName, Stopped)
+        _ <- waitForProjectionStatus(client, projectionName, Stopped)
         deleteResult <- client.deleteProjection(projectionName)
       } yield deleteResult
 
@@ -227,9 +227,9 @@ class ProjectionsClientITest extends AbstractStreamsITest {
 
       val result = for {
         _ <- client.createProjection(projectionName, ProjectionCode, Continuous)
-        stopped <- waitForProjectionStatus(client, projectionName, Running)
+        _ <- waitForProjectionStatus(client, projectionName, Running)
         _ <- client.stopProjection(projectionName)
-        stopped <- waitForProjectionStatus(client, projectionName, Stopped)
+        _ <- waitForProjectionStatus(client, projectionName, Stopped)
         deleteResult <- client.deleteProjection(projectionName)
       } yield deleteResult
 

--- a/client/src/test/scala/eventstore/j/EsConnectionSpec.scala
+++ b/client/src/test/scala/eventstore/j/EsConnectionSpec.scala
@@ -2,7 +2,6 @@ package eventstore
 package j
 
 import java.io.Closeable
-
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import _root_.akka.actor.Status.Failure

--- a/core/src/main/scala-2.12/eventstore/ScalaCompat.scala
+++ b/core/src/main/scala-2.12/eventstore/ScalaCompat.scala
@@ -1,0 +1,20 @@
+package eventstore
+
+import scala.{collection => c}
+
+private[eventstore] object ScalaCompat {
+
+  type IterableOnce[+X] = c.TraversableOnce[X]
+  val IterableOnce      = c.TraversableOnce
+  type LazyList[+T]     = c.immutable.Stream[T]
+
+  object LazyList {
+    val #::                   = c.immutable.Stream.#::
+    def empty[T]: LazyList[T] = c.immutable.Stream.empty[T]
+  }
+
+  implicit class IterableOps[T](private val iterable: c.Iterable[T]) extends AnyVal {
+    def toLazyList: LazyList[T] = iterable.to[LazyList]
+  }
+
+}

--- a/core/src/main/scala-2.13/eventstore/ScalaCompat.scala
+++ b/core/src/main/scala-2.13/eventstore/ScalaCompat.scala
@@ -1,0 +1,7 @@
+package eventstore
+
+private[eventstore] object ScalaCompat {
+  implicit class IterableOps[T](private val iterable: Iterable[T]) extends AnyVal {
+    def toLazyList: LazyList[T] = iterable.to(LazyList)
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0-M5")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "7.0.0-SNAPSHOT"
+ThisBuild / version := "7.0.0-SNAPSHOT"


### PR DESCRIPTION
 - add scala 2.13 support.

 - fix value-discard issues in `SourceStageLogic`, `Client`
   and `ConnectionActor`.

 - fix tests in `ProjectionsClientITest` wrt. `should beSome(X)`
   and `X` is a case object to be `shouldEqual Some(X)` as
   Scala 2.13 fails with a `type mismatch` error.

 - add `ScalaCompat` object in unmanaged sources in
   core project in order to be able to cross compile.

 - change `TestConnection` to use `ScalaCompat` in order to get
   Scala 2.12 and 2.13 working with minimal changes, `LazyList`
   replaces `Stream`.

 - fix shadow warnings and unused variables in `ConnectionActorSpec`
   and `ProjectionsClientITest`.

 - change `OneToMany` to use `Iterable` and `IterableOnce` and
   use `import eventstore.ScalaCompat._` in order to have cross
   builds working.

 - change build.sbt and version.sbt to use recommended syntax
   for scopes.

 - bump sbt-scoverage to 1.6.0-M5 in order to get 2.13 support.