### PR TITLE
all: add tpolecat plugin for recommended scalac options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,6 @@ lazy val commonSettings = Seq(
   organizationHomepage := Some(new URL("http://geteventstore.com")),
   description          := "Event Store JVM Client",
   startYear            := Some(2013),
-
-  scalacOptions ++= commonScalacOptions(scalaVersion.value),
   Test / compile / scalacOptions -= "-Ywarn-value-discard",
   Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings"),
 
@@ -41,23 +39,6 @@ lazy val commonSettings = Seq(
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   publishTo := sonatypePublishTo.value
 )
-
-def commonScalacOptions(scalaVersion: String) = {
-  Seq(
-    "-encoding", "UTF-8",
-    "-feature",
-    "-unchecked",
-    "-deprecation",
-    "-language:existentials",
-    "-language:higherKinds",
-    "-Xfatal-warnings",
-    "-Xlint:-missing-interpolator",
-    "-Xfuture",
-    "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard"
-  ) ++ (if (priorTo2_13(scalaVersion)) Seq("-Yno-adapted-args") else Nil)
-}
 
 def priorTo2_13(scalaVersion: String): Boolean =
   CrossVersion.partialVersion(scalaVersion) match {
@@ -102,11 +83,11 @@ lazy val client = project
   .settings(inConfig(ClusterTest)(Defaults.testTasks): _*)
   .settings(
     moduleName := "eventstore-client",
-    Test / testOptions := Seq(Tests.Filter(_ endsWith "Spec")),
+    Test            / testOptions := Seq(Tests.Filter(_ endsWith "Spec")),
     IntegrationTest / testOptions := Seq(Tests.Filter(_ endsWith "ITest")),
-    ClusterTest / testOptions := Seq(Tests.Filter(_ endsWith "CTest")),
+    ClusterTest     / testOptions := Seq(Tests.Filter(_ endsWith "CTest")),
     IntegrationTest / parallelExecution := false,
-    ClusterTest / parallelExecution := false,
+    ClusterTest     / parallelExecution := false,
     coverageExcludedPackages := "eventstore.j;"
   )
   .settings(

--- a/client/src/main/scala/eventstore/akka/EsConnection.scala
+++ b/client/src/main/scala/eventstore/akka/EsConnection.scala
@@ -30,9 +30,7 @@ class EsConnection(
   implicit val timeout = Timeout(settings.operationTimeout)
 
   def apply[OUT <: Out, IN <: In](out: OUT, credentials: Option[UserCredentials] = None)(
-    implicit
-    outIn: ClassTags[OUT, IN],
-    ec:    ExecutionContext
+    implicit outIn: ClassTags[OUT, IN]
   ): Future[IN] = {
 
     val future = connection ? credentials.fold[OutLike](out)(WithCredentials(out, _))

--- a/client/src/main/scala/eventstore/akka/SubscriptionActor.scala
+++ b/client/src/main/scala/eventstore/akka/SubscriptionActor.scala
@@ -116,12 +116,11 @@ private[eventstore] class SubscriptionActor(
   }
 
   def subscribingFromLast(): Receive = {
-    def subscribed(position: Long) = {
+    def subscribed: Receive =
       liveProcessing(None, Queue())
-    }
 
     subscribeToStream()
-    rcvSubscribeCompleted(subscribed) or
+    rcvSubscribeCompleted(_ ⇒ subscribed) or
       rcvFailureOrUnsubscribe
   }
 

--- a/client/src/main/scala/eventstore/akka/TransactionActor.scala
+++ b/client/src/main/scala/eventstore/akka/TransactionActor.scala
@@ -126,7 +126,7 @@ private[eventstore] class TransactionActor(
       throw error
   }
 
-  class ContinueReceive(transactionId: Long) extends (Queue[StashEntry] => Receive) {
+  private[eventstore] class ContinueReceive(transactionId: Long) extends (Queue[StashEntry] => Receive) {
     val common: Receive = {
       case GetTransactionId => sender() ! TransactionId(transactionId)
     }

--- a/client/src/main/scala/eventstore/akka/cluster/ClusterDiscovererActor.scala
+++ b/client/src/main/scala/eventstore/akka/cluster/ClusterDiscovererActor.scala
@@ -82,7 +82,8 @@ private[eventstore] class ClusterDiscovererActor(
   }
 
   def discover(attempt: Int, failed: Option[InetSocketAddress], seeds: List[InetSocketAddress]) = {
-    def attemptFailed(e: Option[Throwable] = None) = {
+
+    def attemptFailed(e: Option[Throwable]) = {
       if (attempt < maxDiscoverAttempts) {
         e match {
           case Some(th) => log.info("Discovering cluster: attempt {}/{} failed with error: {}", attempt, maxDiscoverAttempts, th)
@@ -167,7 +168,10 @@ private[eventstore] object ClusterDiscovererActor {
     Props(new ClusterDiscovererActor(settings, clusterInfo))
   }
 
-  @SerialVersionUID(1L) final case class GetAddress(failed: Option[InetSocketAddress] = None)
+  @SerialVersionUID(1L) final case class GetAddress(failed: Option[InetSocketAddress])
+  object GetAddress {
+    def apply(): GetAddress = GetAddress(None)
+  }
 
   @SerialVersionUID(1L) final case class Address(value: InetSocketAddress)
 

--- a/client/src/main/scala/eventstore/akka/streams/SourceStageLogic.scala
+++ b/client/src/main/scala/eventstore/akka/streams/SourceStageLogic.scala
@@ -104,7 +104,7 @@ private[eventstore] abstract class SourceStageLogic[T, O <: Ordered[O], P <: O](
 
     def doCatchUp(to: P, stash: Queue[T]): Unit = {
 
-      def onReadCompleted(events: List[T], next: P, endOfStream: Boolean): Unit = {
+      def onReadCompleted(events: List[T], next: P): Unit = {
 
         enqueueAndPush(events: _*)
 
@@ -128,7 +128,7 @@ private[eventstore] abstract class SourceStageLogic[T, O <: Ordered[O], P <: O](
       }
 
       stageActorBecome {
-        rcvRead(onReadCompleted, subscribed()) or
+        rcvRead((es, n, _) ⇒ onReadCompleted(es, n), subscribed()) or
           rcvEventAppeared(onEventAppeared) or
           rcvSubscribed(onResubscribed) or
           rcvUnsubscribed(onUnsubscribeCompleted())

--- a/client/src/main/scala/eventstore/akka/tcp/ConnectionActor.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/ConnectionActor.scala
@@ -133,7 +133,7 @@ private[eventstore] class ConnectionActor(settings: Settings) extends Actor with
               }
             }
 
-            def renewAddress(address: InetSocketAddress, os: Operations): Option[Receive] = {
+            def renewAddress: Reconnect = (_, os) => {
               cd ! GetAddress()
               Some(connecting(None, os, renewAddress))
             }

--- a/client/src/main/scala/eventstore/akka/tcp/EventStoreFlow.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/EventStoreFlow.scala
@@ -54,8 +54,8 @@ private[eventstore] object EventStoreFlow {
     framing atop convert atop autoReply atop serialization atop logging
   }
 
-  private implicit class FlowOps[In](self: Flow[In, In, NotUsed]) {
-    def mapFuture[Out](ordered: Boolean, parallelism: Int)(f: In => Out)(implicit ec: ExecutionContext): Flow[In, Out, NotUsed] = {
+  private implicit class FlowOps[I](self: Flow[I, I, NotUsed]) {
+    def mapFuture[O](ordered: Boolean, parallelism: Int)(f: I => O)(implicit ec: ExecutionContext): Flow[I, O, NotUsed] = {
       if (ordered) self.mapAsync(parallelism) { x => Future { f(x) } }
       else self.mapAsyncUnordered(parallelism) { x => Future { f(x) } }
     }

--- a/client/src/main/scala/eventstore/package.scala
+++ b/client/src/main/scala/eventstore/package.scala
@@ -6,7 +6,7 @@ import java.{util => ju}
 
 package object eventstore {
 
-  private val sinceVersion = "7.0.0"
+  private[eventstore] val sinceVersion = "7.0.0"
 
   type Uuid                = ju.UUID
 

--- a/client/src/main/scala/eventstore/tcp/package.scala
+++ b/client/src/main/scala/eventstore/tcp/package.scala
@@ -6,9 +6,7 @@ import eventstore.{akka => a}
 
 package object tcp extends TypeAliases {
 
-  private val sinceVersion = "7.0.0"
-
-  @deprecated(a.deprecationMsg("ConnectionActor"), since = sinceVersion)
+  @deprecated(a.deprecationMsg("ConnectionActor"), since = "7.0.0")
   val ConnectionActor = a.tcp.ConnectionActor
 
 }

--- a/client/src/test/scala/eventstore/akka/EsConnectionSpec.scala
+++ b/client/src/test/scala/eventstore/akka/EsConnectionSpec.scala
@@ -96,11 +96,11 @@ class EsConnectionSpec extends ActorSpec {
     val connection = new EsConnection(testActor, system)
 
     def verifyOutIn[OUT <: Out, IN <: In](out: OUT, in: In)(implicit outIn: ClassTags[OUT, IN]): Unit = {
-      val future = connection(out)(outIn, system.dispatcher)
+      val future = connection(out)(outIn)
       expectMsg(out)
       future.value must beNone
       lastSender ! in
-      future.value must beSome(Success(in))
+      future.value mustEqual Some(Success(in))
     }
   }
 

--- a/client/src/test/scala/eventstore/akka/HeavyWrite.scala
+++ b/client/src/test/scala/eventstore/akka/HeavyWrite.scala
@@ -24,7 +24,7 @@ class HeavyWrite extends ActorSpec {
       }
       val data = Content(bytes)
 
-      val results = for { n <- 0 until times } yield {
+      val results = for { _ <- 0 until times } yield {
 
         val futures = for { _ <- 0 until writes } yield {
           val es = List.fill(events)(EventData(testName, data = data))

--- a/client/src/test/scala/eventstore/akka/testutil/TestLogger.scala
+++ b/client/src/test/scala/eventstore/akka/testutil/TestLogger.scala
@@ -7,7 +7,7 @@ import _root_.akka.event.LoggingAdapter
 import TestLogger.Item
 import TestLogger.Level
 
-final case class TestLogger private(
+final case class TestLogger private[testutil](
   debug: Boolean            = false,
   info: Boolean             = false,
   warning: Boolean          = false,

--- a/client/src/test/scala/eventstore/j/EsConnectionSpec.scala
+++ b/client/src/test/scala/eventstore/j/EsConnectionSpec.scala
@@ -10,7 +10,7 @@ import eventstore.akka.ActorSpec
 
 class EsConnectionSpec extends ActorSpec {
 
-  val streams = List("plain", "$system", "$$metadata")
+  val streams = List("plain", s"$$system", s"$$$$metadata")
   val existingVersions = List(ExpectedVersion.Any, ExpectedVersion.First, null)
   val versions = ExpectedVersion.NoStream :: existingVersions
   val contents = List(Content("string"), Content(Array[Byte](1, 2, 3)), Content.Json("{}"))

--- a/core/src/main/scala-2.13/eventstore/ScalaCompat.scala
+++ b/core/src/main/scala-2.13/eventstore/ScalaCompat.scala
@@ -1,7 +1,13 @@
 package eventstore
 
+import scala.{collection => c}
+
 private[eventstore] object ScalaCompat {
-  implicit class IterableOps[T](private val iterable: Iterable[T]) extends AnyVal {
+
+  type IterableOnce[T] = c.IterableOnce[T]
+  val IterableOnce     = c.IterableOnce
+
+  implicit class IterableOps[T](private val iterable: c.Iterable[T]) extends AnyVal {
     def toLazyList: LazyList[T] = iterable.to(LazyList)
   }
 }

--- a/core/src/main/scala/eventstore/SystemEventType.scala
+++ b/core/src/main/scala/eventstore/SystemEventType.scala
@@ -1,10 +1,10 @@
 package eventstore
 
 object SystemEventType {
-  val streamDeleted: String = "$streamDeleted"
+  val streamDeleted: String = s"$$streamDeleted"
   val statsCollection: String = "$statsCollected"
   val linkTo: String = "$>"
-  val metadata: String = "$metadata"
+  val metadata: String = s"$$metadata"
   val userCreated: String = "$UserCreated"
   val userUpdated: String = "$UserUpdated"
   val passwordChanged: String = "$PasswordChanged"

--- a/core/src/test/scala/eventstore/EventStreamSpec.scala
+++ b/core/src/test/scala/eventstore/EventStreamSpec.scala
@@ -20,11 +20,11 @@ class EventStreamSpec extends Specification {
     }
 
     "return Metadata if value starts with $$" in {
-      EventStream("$$metadata") mustEqual EventStream.Metadata("metadata")
+      EventStream($$("metadata")) mustEqual EventStream.Metadata("metadata")
     }
 
     "return System if value starts with $" in {
-      EventStream("$system") mustEqual EventStream.System("system")
+      EventStream($("system")) mustEqual EventStream.System("system")
     }
 
     "return Plain if not starts with $" in {
@@ -32,8 +32,8 @@ class EventStreamSpec extends Specification {
     }
 
     "throw exception if starts with $$$$" in {
-      EventStream("$$$stream") must not(throwA[IllegalArgumentException])
-      EventStream("$$$$stream") must throwA[IllegalArgumentException]
+      EventStream($$$("stream"))  must not(throwA[IllegalArgumentException])
+      EventStream($$$$("stream")) must throwA[IllegalArgumentException]
     }
   }
 
@@ -51,7 +51,7 @@ class EventStreamSpec extends Specification {
   "EventStream.HasMetadata" should {
 
     "return System if value starts with $" in {
-      EventStream.HasMetadata("$system") mustEqual EventStream.System("system")
+      EventStream.HasMetadata($("system")) mustEqual EventStream.System("system")
     }
 
     "return Plain if not starts with $" in {
@@ -59,7 +59,7 @@ class EventStreamSpec extends Specification {
     }
 
     "throw exception if starts with $$" in {
-      EventStream.HasMetadata("$$stream") must throwA[IllegalArgumentException]
+      EventStream.HasMetadata($$("stream")) must throwA[IllegalArgumentException]
     }
 
     "throw exception if value is null" in {
@@ -108,7 +108,7 @@ class EventStreamSpec extends Specification {
     }
 
     "throw exception if starts with $" in {
-      EventStream.Plain("$stream") must throwA[IllegalArgumentException]
+      EventStream.Plain($("system")) must throwA[IllegalArgumentException]
     }
 
     "throw exception if value is null" in {
@@ -146,7 +146,7 @@ class EventStreamSpec extends Specification {
     }
 
     "throw exception if starts with $" in {
-      EventStream.System("$stream") must throwA[IllegalArgumentException]
+      EventStream.System($("system")) must throwA[IllegalArgumentException]
     }
 
     "throw exception if value is null" in {
@@ -172,7 +172,7 @@ class EventStreamSpec extends Specification {
 
     "return proper original" in {
       stream.original mustEqual EventStream.Plain("metadata")
-      EventStream.Metadata("$metadata").original mustEqual EventStream.System("metadata")
+      EventStream.Metadata($("metadata")).original mustEqual EventStream.System("metadata")
     }
 
     "be not system stream" in {
@@ -184,7 +184,7 @@ class EventStreamSpec extends Specification {
     }
 
     "throw exception if starts with $$" in {
-      EventStream.Metadata("$$stream") must throwA[IllegalArgumentException]
+      EventStream.Metadata($$("stream")) must throwA[IllegalArgumentException]
     }
 
     "throw exception if value is null" in {
@@ -195,4 +195,9 @@ class EventStreamSpec extends Specification {
       EventStream.Metadata("") must throwA[IllegalArgumentException]
     }
   }
+
+  def $(str: String, times: Int = 1): String = s"${"$" * times}$str"
+  def $$(str: String): String                = $(str, 2)
+  def $$$(str: String): String               = $(str, 3)
+  def $$$$(str: String): String              = $(str, 4)
 }

--- a/core/src/test/scala/eventstore/PositionSpec.scala
+++ b/core/src/test/scala/eventstore/PositionSpec.scala
@@ -33,10 +33,10 @@ class PositionSpec extends Specification {
     ">=" in new PositionScope {
       def verify(p1: Position, p2: Position) = {
         (p1 >= p2) mustEqual ((p1, p2) match {
-          case (Last, Last)                       => true
-          case (_, Last)                          => false
-          case (Last, _)                          => true
-          case (Exact(cp1, pp1), Exact(cp2, pp2)) => p1 > p2 || p1 == p2
+          case (Last, Last)               => true
+          case (_, Last)                  => false
+          case (Last, _)                  => true
+          case (Exact(_, _), Exact(_, _)) => p1 > p2 || p1 == p2
         })
       }
     }
@@ -44,10 +44,10 @@ class PositionSpec extends Specification {
     "<=" in new PositionScope {
       def verify(p1: Position, p2: Position) = {
         (p1 <= p2) mustEqual ((p1, p2) match {
-          case (Last, Last)                       => true
-          case (_, Last)                          => true
-          case (Last, _)                          => false
-          case (Exact(cp1, pp1), Exact(cp2, pp2)) => p1 < p2 || p1 == p2
+          case (Last, Last)               => true
+          case (_, Last)                  => true
+          case (Last, _)                  => false
+          case (Exact(_, _), Exact(_, _)) => p1 < p2 || p1 == p2
         })
       }
     }

--- a/core/src/test/scala/eventstore/operations/SimpleOperationSpec.scala
+++ b/core/src/test/scala/eventstore/operations/SimpleOperationSpec.scala
@@ -93,7 +93,7 @@ class SimpleOperationSpec extends OperationSpec {
     val inspection = new Inspection {
       def expected = Pong.getClass
       def pf = {
-        case x @ Success(Pong)  => Inspection.Decision.Stop
+        case _@ Success(Pong)  => Inspection.Decision.Stop
         case Failure(TestError) => Inspection.Decision.Fail(TestException)
       }
     }

--- a/core/src/test/scala/eventstore/operations/SubscriptionOperationSpec.scala
+++ b/core/src/test/scala/eventstore/operations/SubscriptionOperationSpec.scala
@@ -381,7 +381,7 @@ class SubscriptionOperationSpec extends OperationSpec {
     "stop on unexpected" in foreach(streams) { implicit stream =>
       new UnsubscribingScope {
         val unexpected = stream match {
-          case x: EventStream.Id => SubscribeToStreamCompleted(0)
+          case _: EventStream.Id => SubscribeToStreamCompleted(0)
           case _                 => SubscribeToAllCompleted(0)
         }
         operation.inspectIn(Try(unexpected)) must beLike {
@@ -443,7 +443,7 @@ class SubscriptionOperationSpec extends OperationSpec {
     val operation = SO.Subscribing(subscribeTo, pack, client, ongoing = true, 0)
 
     lazy val subscribeCompleted = stream match {
-      case x: EventStream.Id => SubscribeToStreamCompleted(0)
+      case _: EventStream.Id => SubscribeToStreamCompleted(0)
       case _                 => SubscribeToAllCompleted(0)
     }
   }

--- a/examples/src/main/scala/eventstore/akka/examples/APIsExample.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/APIsExample.scala
@@ -9,9 +9,8 @@ class APIsExample {
   val system = ActorSystem()
 
   def methodCall(): Unit = {
-    import system.dispatcher
     val connection = EsConnection(system)
-    val future = connection apply ReadEvent(EventStream.Id("my-stream"), EventNumber.First)
+    val _ = connection apply ReadEvent(EventStream.Id("my-stream"), EventNumber.First)
   }
 
   def messageSending(): Unit = {

--- a/examples/src/main/scala/eventstore/akka/examples/CountAll.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/CountAll.scala
@@ -19,7 +19,7 @@ class CountAll extends Actor with ActorLogging {
   def receive = count(0)
 
   def count(n: Long, printed: Boolean = false): Receive = {
-    case x: IndexedEvent       => context become count(n + 1)
+    case _: IndexedEvent       => context become count(n + 1)
     case LiveProcessingStarted => log.info("live processing started")
     case ReceiveTimeout if !printed =>
       log.info("count {}", n)

--- a/examples/src/main/scala/eventstore/akka/examples/CountStream.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/CountStream.scala
@@ -27,7 +27,7 @@ class CountStream extends Actor with ActorLogging {
   def receive = count(0)
 
   def count(n: Long, printed: Boolean = false): Receive = {
-    case x: Event              => context become count(n + 1)
+    case _: Event              => context become count(n + 1)
     case LiveProcessingStarted => log.info("live processing started")
     case ReceiveTimeout if !printed =>
       log.info("count {}", n)

--- a/examples/src/main/scala/eventstore/akka/examples/EventStoreExtensionExample.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/EventStoreExtensionExample.scala
@@ -6,7 +6,6 @@ import _root_.akka.actor.ActorSystem
 
 object EventStoreExtensionExample {
   val system = ActorSystem()
-  import system.dispatcher
 
   EventStoreExtension(system).actor ! ReadEvent(EventStream.Id("stream"))
   EventStoreExtension(system).connection(ReadEvent(EventStream.Id("stream")))

--- a/examples/src/main/scala/eventstore/akka/examples/MessagesPerSecond.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/MessagesPerSecond.scala
@@ -22,7 +22,7 @@ class MessagesPerSecond extends Actor with ActorLogging {
   override def receive: Receive = receive(0, Nil, scheduled = false)
 
   def receive(n: Long, ns: List[Long], scheduled: Boolean): Receive = {
-    case x: IndexedEvent =>
+    case _: IndexedEvent =>
       if (!scheduled) context.system.scheduler.scheduleOnce(1.second, self, Tick)
       context become receive(n + 1, ns, scheduled = true)
 

--- a/examples/src/main/scala/eventstore/akka/examples/PersistentSubscriptionExample.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/PersistentSubscriptionExample.scala
@@ -27,8 +27,8 @@ class CountPersistentStream extends Actor with ActorLogging {
 
   def receive: Receive = count(0)
 
-  def count(n: Long, printed: Boolean = false): Receive = {
-    case x: EventRecord =>
+  def count(n: Long): Receive = {
+    case _: EventRecord =>
       log.info("count {}", n)
       context become count(n + 1)
     case LiveProcessingStarted => log.info("live processing started")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,6 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0-M5")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.5")
+
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.7.0"


### PR DESCRIPTION
 - remove our common `scalacOptions` additions that
   now come via tpolecat plugin.

 - remove unused `ExecutionContext` from `EsConnection.apply`.

 - adjust code and tests to get things to compile.