### PR TITLE
all: scala 2.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ jdk:
 language: scala
 
 scala:
+  - 2.13.0
   - 2.12.8
-  - 2.13.0-M5
 
 sudo: required
 
@@ -22,11 +22,11 @@ after_success:
 jobs:
   include:
     - stage: integration
-      scala: 2.12.8
+      scala: 2.13.0
       env: AKKA_TEST_TIMEFACTOR=1.5 AKKA_TEST_LOGLEVEL=OFF
       before_install:
-        - docker pull eventstore/eventstore:release-5.0.0
-        - docker run -d --rm --name eventstore-node -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=1200 eventstore/eventstore:release-5.0.0
+        - docker pull eventstore/eventstore:release-5.0.1
+        - docker run -d --rm --name eventstore-node -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=1200 eventstore/eventstore:release-5.0.1
       script:
         - sbt test:compile
         - travis_retry sbt it:test

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 <table border="0">
   <tr>
     <td><a href="http://www.scala-lang.org">Scala</a> </td>
-    <td>2.12.8/2.11.12</td>
+    <td>2.13.0 / 2.12.8</td>
   </tr>
   <tr>
     <td><a href="http://akka.io">Akka</a> </td>
-    <td>2.5.21</td>
+    <td>2.5.23</td>
   </tr>
   <tr>
     <td><a href="https://eventstore.org">Event Store</a></td>
@@ -22,7 +22,7 @@ We have two APIs available:
 
 We are using [`scala.concurrent.Future`](http://docs.scala-lang.org/overviews/core/futures.html) for asynchronous calls, however it is not friendly enough for Java users.
 In order to make Java devs happy and not reinvent a wheel, we propose to use tools invented by Akka team.
-[Check it out](http://doc.akka.io/docs/akka/2.5.19/java/futures.html)
+[Check it out](http://doc.akka.io/docs/akka/2.5.23/java/futures.html)
 
 ```java
 final EsConnection connection = EsConnectionFactory.create(system);
@@ -51,7 +51,7 @@ connection ! ReadEvent(EventStream.Id("my-stream"), EventNumber.First)
 
 #### Sbt
 ```scala
-libraryDependencies += "com.geteventstore" %% "eventstore-client" % "6.0.0"
+libraryDependencies += "com.geteventstore" %% "eventstore-client" % "7.0.0"
 ```
 
 #### Maven
@@ -59,7 +59,7 @@ libraryDependencies += "com.geteventstore" %% "eventstore-client" % "6.0.0"
 <dependency>
     <groupId>com.geteventstore</groupId>
     <artifactId>eventstore-client_${scala.version}</artifactId>
-    <version>6.0.0</version>
+    <version>7.0.0</version>
 </dependency>
 ```
 
@@ -270,12 +270,14 @@ object ReadEventExample extends App {
     def receive = {
       case ReadEventCompleted(event) =>
         log.info("event: {}", event)
-        context.system.terminate()
+        shutdown()
 
       case Failure(e: EsException) =>
         log.error(e.toString)
-        context.system.terminate()
+        shutdown()
     }
+
+    def shutdown(): Unit = { context.system.terminate(); () }
   }
 }
 ```
@@ -303,12 +305,14 @@ object WriteEventExample extends App {
     def receive = {
       case WriteEventsCompleted(range, position) =>
         log.info("range: {}, position: {}", range, position)
-        context.system.terminate()
+        shutdown()
 
       case Failure(e: EsException) =>
         log.error(e.toString)
-        context.system.terminate()
+        shutdown()
     }
+
+    def shutdown(): Unit = { context.system.terminate();  () }
   }
 }
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -6,14 +6,14 @@ lazy val commonSettings = Seq(
 
   organization         := "com.geteventstore",
   scalaVersion         := crossScalaVersions.value.head,
-  crossScalaVersions   := Seq("2.12.8", "2.13.0-M5"),
+  crossScalaVersions   := Seq("2.13.0", "2.12.8"),
   releaseCrossBuild    := true,
   licenses             := Seq("BSD 3-Clause" -> url("http://raw.github.com/EventStore/EventStore.JVM/master/LICENSE")),
   homepage             := Some(new URL("http://github.com/EventStore/EventStore.JVM")),
   organizationHomepage := Some(new URL("http://geteventstore.com")),
   description          := "Event Store JVM Client",
   startYear            := Some(2013),
-  Test / compile / scalacOptions -= "-Ywarn-value-discard",
+  Test / compile / scalacOptions --= Seq("-Ywarn-value-discard", "-Wvalue-discard"),
   Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings"),
 
   Global / pomExtra := {
@@ -104,7 +104,7 @@ lazy val examples = project
   .settings(commonSettings)
   .settings(
     moduleName := "eventstore-client-examples",
-    scalacOptions -= "-Ywarn-value-discard",
+    scalacOptions --= Seq("-Ywarn-value-discard", "-Wvalue-discard"),
     publish / skip := true,
     coverageExcludedPackages := "eventstore.examples;eventstore.j;"
   )

--- a/client/src/main/scala/eventstore/CoreCompat.scala
+++ b/client/src/main/scala/eventstore/CoreCompat.scala
@@ -1,7 +1,7 @@
 package eventstore
 
-import eventstore.core.{settings ⇒ cs}
-import eventstore.{core ⇒ c}
+import eventstore.core.{settings => cs}
+import eventstore.{core => c}
 
 trait CoreCompat {
 
@@ -142,10 +142,10 @@ trait CoreCompat {
 
   object PersistentSubscription {
 
-    import PersistentSubscriptionSettings.{Default ⇒ D}
+    import PersistentSubscriptionSettings.{Default => D}
     import c.EventStream.Id
-    import c.{PersistentSubscription ⇒ PS}
-    import cs.{PersistentSubscriptionSettings ⇒ PSS}
+    import c.{PersistentSubscription => PS}
+    import cs.{PersistentSubscriptionSettings => PSS}
 
     def create(streamId: Id, groupName: String, settings: PSS): Create = Create(streamId, groupName, settings)
     def update(streamId: Id, groupName: String, settings: PSS): Update = Update(streamId, groupName, settings)

--- a/client/src/main/scala/eventstore/akka/SubscriptionActor.scala
+++ b/client/src/main/scala/eventstore/akka/SubscriptionActor.scala
@@ -120,7 +120,7 @@ private[eventstore] class SubscriptionActor(
       liveProcessing(None, Queue())
 
     subscribeToStream()
-    rcvSubscribeCompleted(_ ⇒ subscribed) or
+    rcvSubscribeCompleted(_ => subscribed) or
       rcvFailureOrUnsubscribe
   }
 

--- a/client/src/main/scala/eventstore/akka/streams/AllStreamsSourceStage.scala
+++ b/client/src/main/scala/eventstore/akka/streams/AllStreamsSourceStage.scala
@@ -29,14 +29,14 @@ private[eventstore] class AllStreamsSourceStage(
       import settings._
 
       final val first: Exact = First
-      final val eventFrom: IndexedEvent ⇒ IndexedEvent = identity
-      final val positionFrom: IndexedEvent ⇒ Exact = _.position
-      final val pointerFrom: Exact ⇒ Long = _.commitPosition
+      final val eventFrom: IndexedEvent => IndexedEvent = identity
+      final val positionFrom: IndexedEvent => Exact = _.position
+      final val pointerFrom: Exact => Long = _.commitPosition
 
       final def operation: ReadFrom = fromPositionExclusive match {
-        case Some(Last)     ⇒ ReadFrom.End
-        case Some(e: Exact) ⇒ ReadFrom.Exact(e)
-        case None           ⇒ ReadFrom.Beginning
+        case Some(Last)     => ReadFrom.End
+        case Some(e: Exact) => ReadFrom.Exact(e)
+        case None           => ReadFrom.Beginning
       }
 
       final def buildReadEventsFrom(next: Exact): Out = ReadAllEvents(
@@ -44,11 +44,11 @@ private[eventstore] class AllStreamsSourceStage(
       )
 
       final def rcvRead(onRead: (List[IndexedEvent], Exact, Boolean) => Unit, onNotExists: => Unit): Receive = {
-        case ReadAllEventsCompleted(events, _, n, Forward) ⇒ onRead(events, n, events.isEmpty)
+        case ReadAllEventsCompleted(events, _, n, Forward) => onRead(events, n, events.isEmpty)
       }
 
-      final def rcvSubscribed(onSubscribed: Option[Exact] ⇒ Unit): Receive = {
-        case SubscribeToAllCompleted(x) ⇒ onSubscribed(Some(Position.Exact(x)))
+      final def rcvSubscribed(onSubscribed: Option[Exact] => Unit): Receive = {
+        case SubscribeToAllCompleted(x) => onSubscribed(Some(Position.Exact(x)))
       }
 
     }

--- a/client/src/main/scala/eventstore/akka/streams/StreamSourceStage.scala
+++ b/client/src/main/scala/eventstore/akka/streams/StreamSourceStage.scala
@@ -30,14 +30,14 @@ private[eventstore] class StreamSourceStage(
       import settings._
 
       final val first: Exact = First
-      final val eventFrom: IndexedEvent ⇒ Event = _.event
-      final val pointerFrom: Exact ⇒ Long = _.value
-      final val positionFrom: Event ⇒ Exact = _.record.number
+      final val eventFrom: IndexedEvent => Event = _.event
+      final val pointerFrom: Exact => Long = _.value
+      final val positionFrom: Event => Exact = _.record.number
 
       final def operation: ReadFrom = fromNumberExclusive match {
-        case Some(Last)     ⇒ ReadFrom.End
-        case Some(e: Exact) ⇒ ReadFrom.Exact(e)
-        case None           ⇒ ReadFrom.Beginning
+        case Some(Last)     => ReadFrom.End
+        case Some(e: Exact) => ReadFrom.Exact(e)
+        case None           => ReadFrom.Beginning
       }
 
       final def buildReadEventsFrom(next: Exact): Out = ReadStreamEvents(
@@ -45,12 +45,12 @@ private[eventstore] class StreamSourceStage(
       )
 
       final def rcvRead(onRead: (List[Event], Exact, Boolean) => Unit, onNotExists: => Unit): Receive = {
-        case ReadStreamEventsCompleted(e, n: Exact, _, eos, _, Forward) ⇒ onRead(e, n, eos)
-        case Failure(_: StreamNotFoundException)                        ⇒ onNotExists
+        case ReadStreamEventsCompleted(e, n: Exact, _, eos, _, Forward) => onRead(e, n, eos)
+        case Failure(_: StreamNotFoundException)                        => onNotExists
       }
 
-      final def rcvSubscribed(onSubscribed: Option[Exact] ⇒ Unit): Receive = {
-        case SubscribeToStreamCompleted(_, subscriptionNumber) ⇒ onSubscribed(subscriptionNumber)
+      final def rcvSubscribed(onSubscribed: Option[Exact] => Unit): Receive = {
+        case SubscribeToStreamCompleted(_, subscriptionNumber) => onSubscribed(subscriptionNumber)
       }
 
     }

--- a/client/src/main/scala/eventstore/j/Builder.scala
+++ b/client/src/main/scala/eventstore/j/Builder.scala
@@ -43,7 +43,7 @@ object Builder {
 
   trait EventDataSnippet[T] extends ChainSet[T] { self: T =>
     import scala.collection.mutable.ListBuffer
-    import scala.collection.JavaConverters._
+    import core.ScalaCompat.JavaConverters._
 
     protected var _events: ListBuffer[EventData] = new ListBuffer()
 

--- a/client/src/main/scala/eventstore/j/EsConnectionImpl.scala
+++ b/client/src/main/scala/eventstore/j/EsConnectionImpl.scala
@@ -2,11 +2,11 @@ package eventstore
 package j
 
 import java.util
-import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import _root_.akka.NotUsed
 import _root_.akka.actor.ActorSystem
 import _root_.akka.stream.javadsl.Source
+import eventstore.core.ScalaCompat.JavaConverters._
 import eventstore.core.ExpectedVersion.Existing
 import eventstore.akka.SubscriptionObserver
 import eventstore.akka.Settings

--- a/client/src/main/scala/eventstore/j/EsTransactionImpl.scala
+++ b/client/src/main/scala/eventstore/j/EsTransactionImpl.scala
@@ -2,7 +2,7 @@ package eventstore.j
 
 import java.util
 import eventstore.EventData
-import scala.collection.JavaConverters._
+import eventstore.core.ScalaCompat.JavaConverters._
 
 class EsTransactionImpl(transaction: eventstore.akka.EsTransaction) extends EsTransaction {
   def getId = transaction.transactionId

--- a/client/src/main/scala/eventstore/package.scala
+++ b/client/src/main/scala/eventstore/package.scala
@@ -1,7 +1,7 @@
 package object eventstore {
 
-  import eventstore.{compat, akka ⇒ a, core ⇒ c}
-  import eventstore.core.{settings ⇒ cs}
+  import eventstore.{compat, akka => a, core => c}
+  import eventstore.core.{settings => cs}
 
   private[eventstore] final val sinceV7: String = "7.0.0"
   private[eventstore] def randomUuid: Uuid      = c.util.uuid.randomUuid

--- a/client/src/test/scala/eventstore/akka/HeavyWrite.scala
+++ b/client/src/test/scala/eventstore/akka/HeavyWrite.scala
@@ -1,7 +1,6 @@
 package eventstore
 package akka
 
-import scala.compat.Platform
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.util.Random
@@ -32,9 +31,9 @@ class HeavyWrite extends ActorSpec {
           connection(writeEvents)
         }
 
-        val start = Platform.currentTime
+        val start = System.currentTimeMillis()
         Await.result(Future.sequence(futures), 10.seconds)
-        val duration = Platform.currentTime - start
+        val duration = System.currentTimeMillis() - start
         duration
       }
 

--- a/client/src/test/scala/eventstore/akka/SubscribeToAllCatchingUpITest.scala
+++ b/client/src/test/scala/eventstore/akka/SubscribeToAllCatchingUpITest.scala
@@ -222,7 +222,7 @@ class SubscribeToAllCatchingUpITest extends TestConnection {
 
       def expectPlainIndexedEvent(max: Duration = Duration.Undefined): IndexedEvent = {
         self.fishForSpecificMessage[IndexedEvent](max) {
-          case e: IndexedEvent if e.event.isPlainEvent ⇒ e.fixDate
+          case e: IndexedEvent if e.event.isPlainEvent => e.fixDate
         }
       }
 

--- a/client/src/test/scala/eventstore/akka/TestConnection.scala
+++ b/client/src/test/scala/eventstore/akka/TestConnection.scala
@@ -156,7 +156,7 @@ abstract class TestConnection extends ActorSpec {
     def expectNonSystemStreamEventAppeared(testKit: TestKitBase = this, max: Duration = Duration.Undefined) = {
 
       val sea = testKit.fishForSpecificMessage[StreamEventAppeared](max) {
-        case sea @ StreamEventAppeared(IndexedEvent(e, _)) if e.isPlainEvent ⇒ sea.fixDate
+        case sea @ StreamEventAppeared(IndexedEvent(e, _)) if e.isPlainEvent => sea.fixDate
       }
 
       sea.event.event.streamId mustEqual streamId

--- a/client/src/test/scala/eventstore/akka/TestData.scala
+++ b/client/src/test/scala/eventstore/akka/TestData.scala
@@ -1,7 +1,7 @@
 package eventstore
 package akka
 
-import eventstore.{PersistentSubscription ⇒ Ps}
+import eventstore.{PersistentSubscription => Ps}
 
 object TestData {
 

--- a/client/src/test/scala/eventstore/akka/streams/StreamSourceSpec.scala
+++ b/client/src/test/scala/eventstore/akka/streams/StreamSourceSpec.scala
@@ -418,7 +418,7 @@ class StreamSourceSpec extends SourceSpec {
     "temporarily halt reading when buffer is full" in new SourceScope {
       connection expectMsg readEvents(0)
       connection reply readCompleted(3, false, event0, event1, event2)
-      connection expectNoMessage ()
+      connection.expectNoMessage()
       expectEvent(event0)
       expectEvent(event1)
       connection expectMsg readEvents(3)

--- a/client/src/test/scala/eventstore/akka/tcp/ConnectionActorSpec.scala
+++ b/client/src/test/scala/eventstore/akka/tcp/ConnectionActorSpec.scala
@@ -71,7 +71,7 @@ class ConnectionActorSpec extends ActorSpec {
       sendConnected()
 
       connection.expectMsgPF() {
-        case PackOut(IdentifyClient(1, _), _, _) ⇒ client ! ClientIdentified
+        case PackOut(IdentifyClient(1, _), _, _) => client ! ClientIdentified
       }
     }
 
@@ -874,7 +874,7 @@ class ConnectionActorSpec extends ActorSpec {
     def connectedAndIdentified(address: InetSocketAddress = settings.address): Unit = {
       sendConnected(address)
       connection.expectMsgPF() {
-        case PackOut(IdentifyClient(1, _), _, _) ⇒ client ! ClientIdentified
+        case PackOut(IdentifyClient(1, _), _, _) => client ! ClientIdentified
       }
     }
 

--- a/client/src/test/scala/eventstore/j/EsConnectionITest.scala
+++ b/client/src/test/scala/eventstore/j/EsConnectionITest.scala
@@ -1,11 +1,11 @@
 package eventstore
 package j
 
-import scala.collection.JavaConverters._
 import _root_.akka.japi.function
 import _root_.akka.stream.ActorMaterializer
 import _root_.akka.stream.scaladsl.{Source, Sink}
 import _root_.akka.stream.testkit.scaladsl.TestSink
+import eventstore.core.ScalaCompat.JavaConverters._
 import eventstore.akka.ActorSpec
 
 class EsConnectionITest extends ActorSpec {

--- a/client/src/test/scala/eventstore/j/EsConnectionSpec.scala
+++ b/client/src/test/scala/eventstore/j/EsConnectionSpec.scala
@@ -2,10 +2,10 @@ package eventstore
 package j
 
 import java.io.Closeable
-import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import _root_.akka.actor.Status.Failure
 import _root_.akka.testkit.TestProbe
+import eventstore.core.ScalaCompat.JavaConverters._
 import eventstore.akka.{ActorSpec, SubscriptionObserver}
 
 class EsConnectionSpec extends ActorSpec {

--- a/core/src/main/scala-2.12/eventstore/core/ScalaCompat.scala
+++ b/core/src/main/scala-2.12/eventstore/core/ScalaCompat.scala
@@ -5,6 +5,8 @@ import scala.{collection => c}
 
 private[eventstore] object ScalaCompat {
 
+  val JavaConverters = scala.collection.JavaConverters
+
   type IterableOnce[+X] = c.TraversableOnce[X]
   val IterableOnce      = c.TraversableOnce
   type LazyList[+T]     = c.immutable.Stream[T]

--- a/core/src/main/scala-2.13/eventstore/core/ScalaCompat.scala
+++ b/core/src/main/scala-2.13/eventstore/core/ScalaCompat.scala
@@ -5,10 +5,13 @@ import scala.{collection => c}
 
 private[eventstore] object ScalaCompat {
 
+  val JavaConverters = scala.jdk.CollectionConverters
+
   type IterableOnce[T] = c.IterableOnce[T]
   val IterableOnce     = c.IterableOnce
 
   implicit class IterableOps[T](private val iterable: c.Iterable[T]) extends AnyVal {
     def toLazyList: LazyList[T] = iterable.to(LazyList)
   }
+
 }

--- a/core/src/main/scala/eventstore/core/Message.scala
+++ b/core/src/main/scala/eventstore/core/Message.scala
@@ -1,7 +1,7 @@
 package eventstore
 package core
 
-import scala.collection.JavaConverters._
+import ScalaCompat.JavaConverters._
 import constants.MaxBatchSize
 
 sealed trait OutLike {

--- a/core/src/main/scala/eventstore/core/settings/ClusterSettings.scala
+++ b/core/src/main/scala/eventstore/core/settings/ClusterSettings.scala
@@ -4,7 +4,7 @@ package settings
 
 import java.net.InetSocketAddress
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
+import ScalaCompat.JavaConverters._
 import com.typesafe.config.Config
 import syntax._
 import cluster.GossipSeedsOrDns

--- a/core/src/main/scala/eventstore/core/tcp/EventStoreProtoFormats.scala
+++ b/core/src/main/scala/eventstore/core/tcp/EventStoreProtoFormats.scala
@@ -3,7 +3,7 @@ package core
 package tcp
 
 import java.time.{Instant, ZoneId, ZonedDateTime}
-import scala.collection.JavaConverters._
+import ScalaCompat.JavaConverters._
 import scala.language.reflectiveCalls
 import scala.util.Try
 import eventstore.core.syntax._
@@ -162,7 +162,7 @@ trait EventStoreProtoFormats extends DefaultProtoFormats with DefaultFormats {
       val builder = j.WriteEvents.newBuilder()
       builder.setEventStreamId(x.streamId.streamId)
       builder.setExpectedVersion(expectedVersion(x.expectedVersion))
-      builder.addAllEvents(x.events.map(EventDataWriter.toProto(_).build()).toIterable.asJava)
+      builder.addAllEvents(x.events.map(EventDataWriter.toProto(_).build()).asJava)
       builder.setRequireMaster(x.requireMaster)
       builder
     }
@@ -210,7 +210,7 @@ trait EventStoreProtoFormats extends DefaultProtoFormats with DefaultFormats {
     def toProto(x: TransactionWrite) = {
       val builder = j.TransactionWrite.newBuilder()
       builder.setTransactionId(x.transactionId)
-      builder.addAllEvents(x.events.map(EventDataWriter.toProto(_).build()).toIterable.asJava)
+      builder.addAllEvents(x.events.map(EventDataWriter.toProto(_).build()).asJava)
       builder.setRequireMaster(x.requireMaster)
       builder
     }
@@ -526,7 +526,7 @@ trait EventStoreProtoFormats extends DefaultProtoFormats with DefaultFormats {
     def toProto(x: Ps.Ack) = {
       val builder = j.PersistentSubscriptionAckEvents.newBuilder()
       builder.setSubscriptionId(x.subscriptionId)
-      builder.addAllProcessedEventIds(x.eventIds.map(protoByteString).toIterable.asJava)
+      builder.addAllProcessedEventIds(x.eventIds.map(protoByteString).asJava)
       builder
     }
   }
@@ -546,7 +546,7 @@ trait EventStoreProtoFormats extends DefaultProtoFormats with DefaultFormats {
 
       val builder = j.PersistentSubscriptionNakEvents.newBuilder()
       builder.setSubscriptionId(x.subscriptionId)
-      builder.addAllProcessedEventIds(x.eventIds.map(protoByteString).toIterable.asJava)
+      builder.addAllProcessedEventIds(x.eventIds.map(protoByteString).asJava)
       builder.setAction(action)
       for { message <- x.message } builder.setMessage(message)
       builder

--- a/core/src/main/scala/eventstore/core/util/IntToByteVector.scala
+++ b/core/src/main/scala/eventstore/core/util/IntToByteVector.scala
@@ -33,5 +33,5 @@ private[eventstore] final class IntToByteVector(bits: Int, signed: Boolean, orde
 }
 
 private[eventstore] object IntToByteVector {
-  val uint8: Int ⇒ Attempt[ByteVector] = new IntToByteVector(8, false, ByteOrdering.BigEndian).encode _
+  val uint8: Int => Attempt[ByteVector] = new IntToByteVector(8, false, ByteOrdering.BigEndian).encode _
 }

--- a/core/src/test/scala/eventstore/core/util/IntToByteVectorSpec.scala
+++ b/core/src/test/scala/eventstore/core/util/IntToByteVectorSpec.scala
@@ -12,12 +12,12 @@ class IntToByteVectorSpec extends Specification {
   "IntToByteVector" should {
 
     "roundtrip (uint8)" in {
-      (0 to 255).map(i ⇒ uint8(i).unsafe.take(1).toInt(signed = false, ordering = ByteOrdering.BigEndian) shouldEqual i)
+      (0 to 255).map(i => uint8(i).unsafe.take(1).toInt(signed = false, ordering = ByteOrdering.BigEndian) shouldEqual i)
     }
 
     "support endianess correctly (uint8)" in {
       val uint8L = new IntToByteVector(8, false, ByteOrdering.LittleEndian).encode _
-      (0 to 255).map(i ⇒ uint8L(i).unsafe shouldEqual uint8(i).unsafe.reverse)
+      (0 to 255).map(i => uint8L(i).unsafe shouldEqual uint8(i).unsafe.reverse)
     }
 
     "return an error when value to apply is out of legal range (uint8)" in {

--- a/examples/src/main/scala/eventstore/akka/examples/ReadEventExample.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/ReadEventExample.scala
@@ -24,11 +24,13 @@ object ReadEventExample extends App {
     def receive = {
       case ReadEventCompleted(event) =>
         log.info("event: {}", event)
-        context.system.terminate()
+        shutdown()
 
       case Failure(e: EsException) =>
         log.error(e.toString)
-        context.system.terminate()
+        shutdown()
     }
+
+    def shutdown(): Unit = { context.system.terminate(); () }
   }
 }

--- a/examples/src/main/scala/eventstore/akka/examples/ReadWriteEvents.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/ReadWriteEvents.scala
@@ -30,7 +30,7 @@ class ReadWriteEventsActor extends Actor with ActorLogging {
       shutdown()
   }
 
-  override def preStart() = read(EventNumber.First)
+  override def preStart(): Unit = { read(EventNumber.First); () }
 
   def receive = rcvStreamNotFound
 
@@ -82,5 +82,5 @@ class ReadWriteEventsActor extends Actor with ActorLogging {
     context.system.scheduler.scheduleOnce(100.millis, connection, msg)
   }
 
-  def shutdown() = context.system.terminate()
+  def shutdown(): Unit = { context.system.terminate();  () }
 }

--- a/examples/src/main/scala/eventstore/akka/examples/TransactionResult.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/TransactionResult.scala
@@ -10,10 +10,12 @@ class TransactionResult extends Actor with ActorLogging {
   def receive = {
     case Failure(x) =>
       log.error(x.toString)
-      context.system.terminate()
+      shutdown()
 
     case x =>
       log.info(x.toString)
-      if (x == CommitCompleted) context.system.terminate()
+      if (x == CommitCompleted) shutdown()
   }
+
+  def shutdown(): Unit = { context.system.terminate(); () }
 }

--- a/examples/src/main/scala/eventstore/akka/examples/WriteEventExample.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/WriteEventExample.scala
@@ -22,11 +22,13 @@ object WriteEventExample extends App {
     def receive = {
       case WriteEventsCompleted(range, position) =>
         log.info("range: {}, position: {}", range, position)
-        context.system.terminate()
+        shutdown()
 
       case Failure(e: EsException) =>
         log.error(e.toString)
-        context.system.terminate()
+        shutdown()
     }
+
+    def shutdown(): Unit = { context.system.terminate();  () }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,15 +4,15 @@ object Dependencies {
 
   val protobufVersion = "3.7.1"
   
-  val `ts-config`   = "com.typesafe" %  "config"      % "1.3.3"
-  val `scodec-bits` = "org.scodec"   %% "scodec-bits" % "1.1.9"
+  val `ts-config`   = "com.typesafe" %  "config"      % "1.3.4"
+  val `scodec-bits` = "org.scodec"   %% "scodec-bits" % "1.1.12"
   val `spray-json`  = "io.spray"     %% "spray-json"  % "1.3.5"
   val specs2        = "org.specs2"   %% "specs2-core" % "4.5.1"
 
   ///
 
   object Akka {
-    private val version = "2.5.22"
+    private val version = "2.5.23"
     val actor            = "com.typesafe.akka" %% "akka-actor"          % version
     val stream           = "com.typesafe.akka" %% "akka-stream"         % version
     val testkit          = "com.typesafe.akka" %% "akka-testkit"        % version

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,10 +8,10 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0-M5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.5")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.6")
 
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.7.0"


### PR DESCRIPTION
 - adjust code according to changes from Scala version
   2.13.0-M5 to 2.13.0.

 - bump dependencies:
   - akka:2.5.23
   - scodec-bits:1.1.12
   - typesafe-config:1.3.4

 - make 2.13.0 default for build.sbt and travis

 - bump sbt plugins:
   - tpolecat-plugin: 0.1.6
   - sbt-scoverage: 1.6.0

 - adjust README to changes in example code.