### PR TITLE
ci: fix environment vars for 20.6.x + fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
       env: AKKA_TEST_TIMEFACTOR=1.5 AKKA_TEST_LOGLEVEL=OFF ES_TEST_ADDRESS_PORT=1114 ES_TEST_HTTP_PORT=2114 ES_TEST_IS_20_SERIES=true
       before_install:
         - docker pull quay.io/ahjohannessen/eventstore-20.6.0-bionic
-        - docker run -d --rm --name eventstore-node-20 -p 2114:2113 -p 1114:1113 -e EVENTSTORE_DEV=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True -e EVENTSTORE_RUN_PROJECTIONS=All quay.io/ahjohannessen/eventstore-20.6.0-bionic
+        - docker run -d --rm --name eventstore-node-20 -p 2114:2113 -p 1114:1113 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True -e EVENTSTORE_RUN_PROJECTIONS=All quay.io/ahjohannessen/eventstore-20.6.0-bionic
       script:
         - sbt test:compile
         - travis_retry sbt it:test
@@ -48,9 +48,9 @@ jobs:
       before_install:
         - docker pull quay.io/ahjohannessen/eventstore-20.6.0-bionic
         - docker network create --subnet=172.18.0.0/16 es-net-20
-        - docker run -d --rm --name es1 --net=es-net-20 --ip 172.18.0.2 -p 2114:2113 -p 1114:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.3:2113,172.18.0.4:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_DEV=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True quay.io/ahjohannessen/eventstore-20.6.0-bionic
-        - docker run -d --rm --name es2 --net=es-net-20 --ip 172.18.0.3 -p 2115:2113 -p 1115:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.2:2113,172.18.0.4:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_DEV=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True quay.io/ahjohannessen/eventstore-20.6.0-bionic
-        - docker run -d --rm --name es3 --net=es-net-20 --ip 172.18.0.4 -p 2116:2113 -p 1116:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.2:2113,172.18.0.3:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_DEV=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True quay.io/ahjohannessen/eventstore-20.6.0-bionic
+        - docker run -d --rm --name es1 --net=es-net-20 --ip 172.18.0.2 -p 2114:2113 -p 1114:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.3:2113,172.18.0.4:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True quay.io/ahjohannessen/eventstore-20.6.0-bionic
+        - docker run -d --rm --name es2 --net=es-net-20 --ip 172.18.0.3 -p 2115:2113 -p 1115:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.2:2113,172.18.0.4:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True quay.io/ahjohannessen/eventstore-20.6.0-bionic
+        - docker run -d --rm --name es3 --net=es-net-20 --ip 172.18.0.4 -p 2116:2113 -p 1116:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.2:2113,172.18.0.3:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True quay.io/ahjohannessen/eventstore-20.6.0-bionic
       script:
         - sbt test:compile
         - travis_retry sbt c:test

--- a/client/src/test/scala/eventstore/akka/TransactionITest.scala
+++ b/client/src/test/scala/eventstore/akka/TransactionITest.scala
@@ -4,8 +4,6 @@ package akka
 import _root_.akka.testkit.TestProbe
 import ExpectedVersion._
 
-import scala.util.Try
-
 class TransactionITest extends TestConnection {
 
   implicit val direction = ReadDirection.Forward
@@ -97,7 +95,7 @@ class TransactionITest extends TestConnection {
 
       // This is due to:
       // https://github.com/EventStore/EventStore/commit/0db40ab6a1b667060fef9948fc5135b90d4a9b34#diff-b20ab1e660cda65b9fb97a8271bfc669R77
-      val positionMustBeSome = isES20Series
+      val positionMustBeSome = testutil.isES20Series
 
       val transactionId2 = transactionStart(Any)
       transactionWrite(event)(transactionId2)
@@ -105,9 +103,6 @@ class TransactionITest extends TestConnection {
       streamEvents mustEqual List(event)
     }
   }
-
-  private def isES20Series: Boolean =
-    sys.env.get("ES_TEST_IS_20_SERIES").flatMap(v => Try(v.toBoolean).toOption).getOrElse(false)
 
   private trait TransactionScope extends TestConnectionScope {
 

--- a/client/src/test/scala/eventstore/akka/security/UserManagementITest.scala
+++ b/client/src/test/scala/eventstore/akka/security/UserManagementITest.scala
@@ -10,6 +10,8 @@ import eventstore.core.util.PasswordHashAlgorithm
 
 class UserManagementITest extends ActorSpec {
 
+  skipAllIf(testutil.isES20Series) // due to --insecure node setting disables user management
+
   "admin" should {
     "be authenticated" in new UserScope {
       actor ! Authenticate.withCredentials(UserCredentials.DefaultAdmin)
@@ -53,6 +55,7 @@ class UserManagementITest extends ActorSpec {
 
       expectNotAuthenticated()
     }
+
   }
 
   trait UserScope extends ActorScope {

--- a/client/src/test/scala/eventstore/akka/testutil/testutil.scala
+++ b/client/src/test/scala/eventstore/akka/testutil/testutil.scala
@@ -1,9 +1,15 @@
 package eventstore
 package akka
 
+import scala.util.Try
+
 package object testutil {
 
   def byteStringInt8(xs: Int*): ByteString =
     ByteString(xs.map(_.toByte).toArray)
+
+  def isES20Series: Boolean =
+    sys.env.get("ES_TEST_IS_20_SERIES").flatMap(v => Try(v.toBoolean).toOption).getOrElse(false)
+
 
 }


### PR DESCRIPTION
 - due to `--insecure` mode entails that `$users` is not present
   projections integration test fails. Fix is to create a stream
   that is always there. Furtermore, user management integration
   tests are skipped if we are on ES 20.6.x series (for now).