### PR TITLE
tls: improve TLS support

### DIFF
--- a/client/src/main/scala/eventstore/akka/ProjectionsClient.scala
+++ b/client/src/main/scala/eventstore/akka/ProjectionsClient.scala
@@ -6,6 +6,7 @@ import scala.concurrent.Future
 import _root_.akka.NotUsed
 import _root_.akka.actor.ActorSystem
 import _root_.akka.http.scaladsl.Http
+import _root_.akka.http.scaladsl._
 import _root_.akka.http.scaladsl.model._
 import _root_.akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials}
 import _root_.akka.http.scaladsl.unmarshalling.Unmarshal
@@ -114,7 +115,8 @@ class ProjectionsClient(settings: Settings = Settings.Default, system: ActorSyst
     val connectionPool = if (uri.scheme == "http") {
       httpExt.cachedHostConnectionPool[Unit](uri.authority.host.address(), uri.authority.port)
     } else {
-      httpExt.cachedHostConnectionPoolHttps[Unit](uri.authority.host.address(), uri.authority.port)
+      val ctx = ConnectionContext.httpsClient(Tls.createSSLContext(system))
+      httpExt.cachedHostConnectionPoolHttps[Unit](uri.authority.host.address(), uri.authority.port, ctx)
     }
 
     Flow[HttpRequest]

--- a/client/src/main/scala/eventstore/akka/Settings.scala
+++ b/client/src/main/scala/eventstore/akka/Settings.scala
@@ -23,7 +23,7 @@ import eventstore.{akka => a}
  * @param resolveLinkTos Whether to resolve LinkTo events automatically
  * @param requireMaster Whether or not to require Event Store to refuse serving read or write request if it is not master
  * @param readBatchSize Number of events to be retrieved by client as single message
- * @param enableTcpTls Whether TLS should be enabled for TCP connections. TLS setup is loaded from akka.ssl-config when enabled.
+ * @param enableTcpTls Whether TLS should be enabled for TCP connections. TLS setup is loaded from eventstore.ssl-config when enabled.
  * @param http Url to access eventstore though the Http API. When https is used, TLS setup is loaded from akka.ssl-config.
  * @param serializationParallelism The number of serialization/deserialization functions to be run in parallel
  * @param serializationOrdered Serialization done asynchronously and these futures may complete in any order, but results will be used with preserved order if set to true

--- a/client/src/main/scala/eventstore/akka/Tls.scala
+++ b/client/src/main/scala/eventstore/akka/Tls.scala
@@ -1,12 +1,11 @@
 package eventstore
 package akka
-package tcp
 
 import javax.net.ssl._
-import _root_.akka.actor._
 import com.typesafe.config.Config
 import com.typesafe.sslconfig.ssl._
 import com.typesafe.sslconfig.akka.util.AkkaLoggerFactory
+import _root_.akka.actor._
 
 private[eventstore] object Tls {
 
@@ -21,16 +20,23 @@ private[eventstore] object Tls {
     builder.build()
   }
 
-  def createSSLEngine(sslContext: SSLContext): SSLEngine = {
-    val engine = sslContext.createSSLEngine()
+  def createSSLEngine(host: String, port: Int, sslContext: SSLContext): SSLEngine = {
+    val engine = sslContext.createSSLEngine(host, port)
     engine.setUseClientMode(true)
+
+    engine.setSSLParameters({
+       val params = engine.getSSLParameters
+       params.setEndpointIdentificationAlgorithm("https")
+       params
+    })
+
     engine
   }
 
   def sslConfigSettings(config: Config): SSLConfigSettings = {
-    val akkaOverrides = config.getConfig("akka.ssl-config")
+    val overrides = config.getConfig("eventstore.ssl-config")
     val defaults = config.getConfig("ssl-config")
-    SSLConfigFactory.parse(akkaOverrides.withFallback(defaults))
+    SSLConfigFactory.parse(overrides.withFallback(defaults))
   }
 
 }

--- a/client/src/main/scala/eventstore/akka/tcp/ConnectionActor.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/ConnectionActor.scala
@@ -367,10 +367,12 @@ private[eventstore] class ConnectionActor(settings: Settings) extends Actor with
 
     import settings.{connectionTimeout, heartbeatTimeout, bufferSize, bufferOverflowStrategy}
 
-    def secureConnection(ctx: SSLContext) = tcp.outgoingConnectionWithTls(
-      address, () => Tls.createSSLEngine(ctx), None, Nil, connectionTimeout, heartbeatTimeout,
-      _ => Success(()), IgnoreComplete
-    )
+    def secureConnection(ctx: SSLContext) = {
+      def createEngine() = Tls.createSSLEngine(address.getHostString, address.getPort, ctx)
+      tcp.outgoingConnectionWithTls(
+        address, createEngine, None, Nil, connectionTimeout, heartbeatTimeout,_ => Success(()), IgnoreComplete
+      )
+    }
 
     def insecureConnection = tcp.outgoingConnection(
       remoteAddress = address, connectTimeout = connectionTimeout, idleTimeout = heartbeatTimeout

--- a/client/src/test/resources/es20-tls.conf
+++ b/client/src/test/resources/es20-tls.conf
@@ -1,7 +1,16 @@
 include "application.conf"
 
-akka.ssl-config.trustManager.stores = [{ type = "PEM", path = ${ES_TEST_CERTIFICATE_FILE} }]
-eventstore.enable-tcp-tls = true
-eventstore.enable-tcp-tls = ${?ES_TEST_ENABLE_TCP_TLS}
+eventstore {
 
+  ssl-config.trustManager.stores = [
+    { type = "PEM", path = ${ES_TEST_CERTIFICATE_FILE} }
+  ]
+
+  http.protocol = "https"
+  http.protocol = ${?ES_TEST_HTTP_PROTOCOL}
+
+  enable-tcp-tls = true
+  enable-tcp-tls = ${?ES_TEST_ENABLE_TCP_TLS}
+
+}
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -6,14 +6,21 @@ eventstore {
   }
 
   http {
-    # When 'https' is used then TLS settings are loaded from akka.ssl-config
+    # When 'https' is used then TLS settings are loaded from eventstore.ssl-config
     protocol = "http" # http | https
     port = 2113
     prefix = ""
   }
 
-  # When TLS is enabled then TLS settings are loaded from akka.ssl-config
+  # When TLS is enabled then TLS settings are loaded from eventstore.ssl-config
   enable-tcp-tls = false
+
+  # Configure overrides to ssl-configuration here.
+  # Note: Only protocol, keyManager & trustManager sections are considered.
+  # See https://lightbend.github.io/ssl-config/KeyStores.html
+  ssl-config {
+    protocol = "TLSv1.2"
+  }
 
   # The desired connection timeout
   connection-timeout = 1s

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,9 +5,9 @@ object Dependencies {
   val protobufVersion = "3.7.1"
   
   val `ts-config`   = "com.typesafe" %  "config"      % "1.4.0"
-  val `scodec-bits` = "org.scodec"   %% "scodec-bits" % "1.1.17"
+  val `scodec-bits` = "org.scodec"   %% "scodec-bits" % "1.1.18"
   val `spray-json`  = "io.spray"     %% "spray-json"  % "1.3.5"
-  val specs2        = "org.specs2"   %% "specs2-core" % "4.10.0"
+  val specs2        = "org.specs2"   %% "specs2-core" % "4.10.3"
 
   ///
 
@@ -20,7 +20,7 @@ object Dependencies {
   }
 
   object AkkaHttp {
-    private val version = "10.1.12"
+    private val version = "10.2.0"
     val http              = "com.typesafe.akka" %% "akka-http"            % version
     val `http-spray-json` = "com.typesafe.akka" %% "akka-http-spray-json" % version
   }


### PR DESCRIPTION
 - akka http 10.2.0 requires that you provide your own `SSLContext`
   via `ConnectionContext.https` and has deprecated usage of
   `AkkaSSLConfig`.

 - move `Tls` object to `akka.eventstore` as it is used by http
   now as well.

 - move `ssl-config` under eventstore config instead of relying
   on akka.