### PR TITLE
TLS support for Eventstore v5.x

### DIFF
--- a/client/src/main/scala/eventstore/akka/cluster/ClusterInfoOf.scala
+++ b/client/src/main/scala/eventstore/akka/cluster/ClusterInfoOf.scala
@@ -20,7 +20,7 @@ private[eventstore] object ClusterInfoOf {
 
   type FutureFunc = InetSocketAddress => Future[ClusterInfo]
 
-  def apply(useTls: Boolean)(implicit system: ActorSystem): FutureFunc = {
+  def apply()(implicit system: ActorSystem): FutureFunc = {
 
     import SprayJsonSupport._
     import ClusterJsonProtocol._
@@ -28,24 +28,17 @@ private[eventstore] object ClusterInfoOf {
 
     val http = Http(system)
     val acceptHeader = headers.Accept(MediaRange(MediaTypes.`application/json`))
-    val sslContext: Option[SSLContext] = if(useTls) Some(Tls.createSSLContext(system)) else None
 
     val pools = TrieMap.empty[Uri, Flow[(HttpRequest, Unit), (Try[HttpResponse], Unit), HostConnectionPool]]
 
     def clusterInfo(address: InetSocketAddress) = {
 
-      val protocol = if(useTls) "https" else "http"
+      val protocol = "http"
       val host = address.getHostString
       val port = address.getPort
       val uri = Uri(s"$protocol://$host:$port/gossip?format=json")
 
-      val connectionPool = sslContext match {
-        case Some(sc) =>
-          val cc = ConnectionContext.httpsClient(sc)
-          http.cachedHostConnectionPoolHttps[Unit](uri.authority.host.address(), uri.authority.port, cc)
-        case None =>
-          http.cachedHostConnectionPool[Unit](uri.authority.host.address(), uri.authority.port)
-      }
+      val connectionPool = http.cachedHostConnectionPool[Unit](uri.authority.host.address(), uri.authority.port)
 
       val req = HttpRequest(uri = uri, headers = List(acceptHeader))
       val pool = pools.getOrElseUpdate(uri, connectionPool)

--- a/client/src/main/scala/eventstore/akka/tcp/ConnectionActor.scala
+++ b/client/src/main/scala/eventstore/akka/tcp/ConnectionActor.scala
@@ -344,7 +344,7 @@ private[eventstore] class ConnectionActor(settings: Settings) extends Actor with
   }
 
   def newClusterDiscoverer(settings: ClusterSettings, useTls: Boolean): ActorRef = {
-    context.actorOf(ClusterDiscovererActor.props(settings, ClusterInfoOf(useTls).apply), "cluster")
+    context.actorOf(ClusterDiscovererActor.props(settings, ClusterInfoOf().apply, useTls), "cluster")
   }
 
   def credentials(x: OutLike): Option[UserCredentials] = x match {

--- a/client/src/test/scala/eventstore/akka/cluster/ClusterDiscovererActorCTest.scala
+++ b/client/src/test/scala/eventstore/akka/cluster/ClusterDiscovererActorCTest.scala
@@ -23,6 +23,6 @@ class ClusterDiscovererActorCTest extends ActorSpec {
       "127.0.0.1" :: 2116
     )
     val settings = ClusterSettings(seeds)
-    val actor = system.actorOf(ClusterDiscovererActor.props(settings, ClusterInfoOf(useTls = false).apply))
+    val actor = system.actorOf(ClusterDiscovererActor.props(settings, ClusterInfoOf().apply, useTls = false))
   }
 }

--- a/examples/src/main/scala/eventstore/akka/examples/DiscoverCluster.scala
+++ b/examples/src/main/scala/eventstore/akka/examples/DiscoverCluster.scala
@@ -17,7 +17,7 @@ object DiscoverCluster extends App {
     new InetSocketAddress("127.0.0.1", 2113),
     new InetSocketAddress("127.0.0.1", 3113)
   ))
-  val discoverer = system.actorOf(ClusterDiscovererActor.props(settings, ClusterInfoOf(useTls = false)), "discoverer")
+  val discoverer = system.actorOf(ClusterDiscovererActor.props(settings, ClusterInfoOf(), useTls = false), "discoverer")
   system.actorOf(Props(classOf[DiscoverCluster], discoverer))
 }
 


### PR DESCRIPTION
We are running Eventstore v5.x with TLS. 

From docs on v5.x TLS on gossip port is not supported.
https://eventstore.com/docs/server/command-line-arguments/index.html#environment-variables

When TLS is enabled on client, TLS is used in ClusterInfoOf on gossip request. Is this possible on Eventstore v5.x?
When TLS is enabled on client ClusterDiscovererActor does not use secure tcp. 

This PR solve our issue connecting to Eventstore 5.x with TLS. Changes is not tested with Eventstore v20.x

Kind regards
Audun