### PR TITLE
misc: support for esdb 21.10.x

### DIFF
--- a/.docker/esdb-cluster.sh
+++ b/.docker/esdb-cluster.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR=$(dirname $BASH_SOURCE)
+docker-compose -p esdb-cluster -f $SCRIPT_DIR/esdb-cluster.yml "$@"

--- a/.docker/esdb-cluster.yml
+++ b/.docker/esdb-cluster.yml
@@ -1,0 +1,67 @@
+version: '3.8'
+services:
+
+  esdb01:
+    image: eventstore/eventstore:21.10.0-bionic
+    environment:
+      - EVENTSTORE_MEM_DB=True
+      - EVENTSTORE_ENABLE_EXTERNAL_TCP=True
+      - EVENTSTORE_ENABLE_ATOM_PUB_OVER_HTTP=true
+      - EVENTSTORE_DISCOVER_VIA_DNS=False
+      - EVENTSTORE_INSECURE=True
+      - EVENTSTORE_GOSSIP_SEED=172.24.0.3:2113,172.24.0.4:2113
+      - EVENTSTORE_CLUSTER_SIZE=3
+      - EVENTSTORE_INT_IP=172.24.0.2
+    ports:
+      - 2114:2113
+      - 1114:1113
+    networks:
+      esdb_cluster_network:
+        ipv4_address: 172.24.0.2
+    restart: unless-stopped
+
+  esdb02:
+    image: eventstore/eventstore:21.10.0-bionic
+    environment:
+      - EVENTSTORE_MEM_DB=True
+      - EVENTSTORE_ENABLE_EXTERNAL_TCP=True
+      - EVENTSTORE_ENABLE_ATOM_PUB_OVER_HTTP=true
+      - EVENTSTORE_DISCOVER_VIA_DNS=False
+      - EVENTSTORE_INSECURE=True
+      - EVENTSTORE_GOSSIP_SEED=172.24.0.2:2113,172.24.0.4:2113
+      - EVENTSTORE_CLUSTER_SIZE=3
+      - EVENTSTORE_INT_IP=172.24.0.3
+    ports:
+      - 2115:2113
+      - 1115:1113
+    networks:
+      esdb_cluster_network:
+        ipv4_address: 172.24.0.3
+    restart: unless-stopped
+
+  esdb03:
+    image: eventstore/eventstore:21.10.0-bionic
+    environment:
+      - EVENTSTORE_MEM_DB=True
+      - EVENTSTORE_ENABLE_EXTERNAL_TCP=True
+      - EVENTSTORE_ENABLE_ATOM_PUB_OVER_HTTP=true
+      - EVENTSTORE_DISCOVER_VIA_DNS=False
+      - EVENTSTORE_INSECURE=True
+      - EVENTSTORE_GOSSIP_SEED=172.24.0.2:2113,172.24.0.3:2113
+      - EVENTSTORE_CLUSTER_SIZE=3      
+      - EVENTSTORE_INT_IP=172.24.0.4
+    ports:
+      - 2116:2113
+      - 1116:1113
+    networks:
+      esdb_cluster_network:
+        ipv4_address: 172.24.0.4
+    restart: unless-stopped
+
+networks:
+  esdb_cluster_network:
+    name: esdb-cluster-net
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.24.0.0/16

--- a/.docker/esdb-single.sh
+++ b/.docker/esdb-single.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR=$(dirname $BASH_SOURCE)
+docker-compose -p esdb-single -f $SCRIPT_DIR/esdb-single.yml "$@"

--- a/.docker/esdb-single.yml
+++ b/.docker/esdb-single.yml
@@ -1,0 +1,52 @@
+version: '3.8'
+services:
+  volumes-provisioner:
+    image: hasnat/volumes-provisioner
+    environment:
+      PROVISION_DIRECTORIES: "1000:1000:0755:/tmp/certs"
+    volumes:
+    - "../certs/single:/tmp/certs"
+    network_mode: none
+  cert-gen:
+    image: eventstore/es-gencert-cli:1.0.2
+    entrypoint: bash
+    command: >
+      -c "es-gencert-cli create-ca -out /tmp/certs/ca &&
+          es-gencert-cli create-node -ca-certificate /tmp/certs/ca/ca.crt -ca-key /tmp/certs/ca/ca.key -out \
+          /tmp/certs/node1 -ip-addresses 127.0.0.1,172.22.0.2 -dns-names localhost"
+    user: "1000:1000"
+    volumes:
+      - "../certs/single:/tmp/certs"
+    depends_on:
+      - volumes-provisioner
+  esdb:
+    image: eventstore/eventstore:21.10.0-bionic
+    environment:
+      - EVENTSTORE_MEM_DB=True
+      - EVENTSTORE_ENABLE_EXTERNAL_TCP=True
+      - EVENTSTORE_RUN_PROJECTIONS=All
+      - EVENTSTORE_ENABLE_ATOM_PUB_OVER_HTTP=true
+      - EVENTSTORE_INT_IP=172.22.0.2
+      - EVENTSTORE_ADVERTISE_HOST_TO_CLIENT_AS=127.0.0.1   
+      - EVENTSTORE_TRUSTED_ROOT_CERTIFICATES_PATH=/etc/eventstore/certs/ca
+      - EVENTSTORE_CERTIFICATE_FILE=/etc/eventstore/certs/node1/node.crt
+      - EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE=/etc/eventstore/certs/node1/node.key
+    ports:
+      - 2114:2113
+      - 1114:1113
+    networks:
+      esdb_single_network:
+        ipv4_address: 172.22.0.2
+    volumes:
+      - ../certs/single:/etc/eventstore/certs
+    restart: unless-stopped
+    depends_on:
+      - cert-gen
+
+networks:
+  esdb_single_network:
+    name: esdb-single-net
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.22.0.0/16

--- a/.docker/legacy-cluster.sh
+++ b/.docker/legacy-cluster.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR=$(dirname $BASH_SOURCE)
+docker-compose -p legacy-cluster -f $SCRIPT_DIR/legacy-cluster.yml "$@"

--- a/.docker/legacy-cluster.yml
+++ b/.docker/legacy-cluster.yml
@@ -1,0 +1,55 @@
+version: '3.8'
+services:
+
+  legacy-esdb01:
+    image: eventstore/eventstore:release-5.0.11
+    environment:
+      - EVENTSTORE_MEM_DB=True
+      - EVENTSTORE_DISCOVER_VIA_DNS=False
+      - EVENTSTORE_GOSSIP_SEED=172.25.0.3:2112,172.25.0.4:2112
+      - EVENTSTORE_CLUSTER_SIZE=3
+    ports:
+      - 2114:2113
+      - 1114:1113
+    networks:
+      legacy_cluster_network:
+        ipv4_address: 172.25.0.2
+    restart: unless-stopped
+
+  legacy-esdb02:
+    image: eventstore/eventstore:release-5.0.11
+    environment:
+      - EVENTSTORE_MEM_DB=True
+      - EVENTSTORE_DISCOVER_VIA_DNS=False
+      - EVENTSTORE_GOSSIP_SEED=172.25.0.2:2112,172.25.0.4:2112
+      - EVENTSTORE_CLUSTER_SIZE=3
+    ports:
+      - 2115:2113
+      - 1115:1113
+    networks:
+      legacy_cluster_network:
+        ipv4_address: 172.25.0.3
+    restart: unless-stopped
+
+  legacy-esdb03:
+    image: eventstore/eventstore:release-5.0.11
+    environment:
+      - EVENTSTORE_MEM_DB=True
+      - EVENTSTORE_DISCOVER_VIA_DNS=False
+      - EVENTSTORE_GOSSIP_SEED=172.25.0.2:2112,172.25.0.3:2112
+      - EVENTSTORE_CLUSTER_SIZE=3
+    ports:
+      - 2116:2113
+      - 1116:1113
+    networks:
+      legacy_cluster_network:
+        ipv4_address: 172.25.0.4
+    restart: unless-stopped
+
+networks:
+  legacy_cluster_network:
+    name: legacy-cluster-net
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.25.0.0/16

--- a/.docker/legacy-single.sh
+++ b/.docker/legacy-single.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR=$(dirname $BASH_SOURCE)
+docker-compose -p legacy-single -f $SCRIPT_DIR/legacy-single.yml "$@"

--- a/.docker/legacy-single.yml
+++ b/.docker/legacy-single.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+
+  legacy-esdb:
+    image: eventstore/eventstore:release-5.0.11
+    environment:
+      - EVENTSTORE_MEM_DB=True
+      - EVENTSTORE_STATS_PERIOD_SEC=24000
+    ports:
+      - 2113:2113
+      - 1113:1113
+    networks:
+      legacy_single_network:
+        ipv4_address: 172.23.0.2
+    restart: unless-stopped
+
+networks:
+  legacy_single_network:
+    name: legacy-single-net
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.23.0.0/16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,188 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+    tags: [v*]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+
+  regular:
+    name: Regurlar Tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.7, 2.12.15]
+        java: [adopt@1.8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Run Tests
+        env:
+          AKKA_TEST_LOGLEVEL: OFF      
+        run: sbt ++${{ matrix.scala }} test:compile test
+
+  esdb-single:
+    name: Integration Tests
+    needs: [regular]
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.7]
+        java: [adopt@1.8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Start ESDB
+        run: |
+          pushd .docker
+          ./esdb-single.sh up -d
+          popd
+
+      - name: Run Tests
+        env:
+          AKKA_TEST_TIMEFACTOR: 1.5
+          AKKA_TEST_LOGLEVEL: OFF
+          ES_TEST_ADDRESS_PORT: 1114
+          ES_TEST_HTTP_PORT: 2114
+          ES_TEST_IS_20_SERIES: true
+          ES_TEST_CERTIFICATE_FILE: ${{ github.workspace }}/certs/single/ca/ca.crt
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: sbt ++${{ matrix.scala }} -J-Dconfig.resource=es20-tls.conf test:compile it:test
+
+      - name: Stop ESDB
+        if: always()
+        run: |
+          pushd .docker
+          ./esdb-single.sh down
+          popd
+
+  esdb-cluster:
+    name: Cluster Tests
+    needs: [regular]
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.7]
+        java: [adopt@1.8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Start ESDB Cluster
+        run: |
+          pushd .docker
+          ./esdb-cluster.sh up -d
+          popd
+
+      - name: Run Tests
+        env:
+          AKKA_TEST_TIMEFACTOR: 1.5
+          AKKA_TEST_LOGLEVEL: OFF
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: sbt ++${{ matrix.scala }} test:compile c:test
+
+      - name: Stop ESDB Cluster
+        if: always()
+        run: |
+          pushd .docker
+          ./esdb-cluster.sh down
+          popd
+
+  legacy-it:
+    name: Legacy Integration Tests 
+    needs: [regular]
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.7]
+        java: [adopt@1.8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Start Legacy ESDB
+        run: |
+          pushd .docker
+          ./legacy-single.sh up -d
+          popd
+
+      - name: Run Tests
+        env:
+          AKKA_TEST_TIMEFACTOR: 1.5
+          AKKA_TEST_LOGLEVEL: OFF
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: sbt ++${{ matrix.scala }} test:compile it:test
+
+      - name: Stop Legacy ESDB
+        if: always()
+        run: |
+          pushd .docker
+          ./legacy-single.sh down
+          popd
+
+  legacy-cluster:
+    name: Legacy Cluster Tests
+    needs: [regular]
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.7]
+        java: [adopt@1.8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Start Legacy ESDB Cluster
+        run: |
+          pushd .docker
+          ./legacy-cluster.sh up -d
+          popd
+
+      - name: Run Tests
+        env:
+          AKKA_TEST_TIMEFACTOR: 1.5
+          AKKA_TEST_LOGLEVEL: OFF
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: sbt ++${{ matrix.scala }} test:compile c:test
+
+      - name: Stop Legacy ESDB Cluster
+        if: always()
+        run: |
+          pushd .docker
+          ./legacy-cluster.sh down
+          popd

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ metals.sbt
 EventStore.Net
 
 .java-version
+
+certs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
+
 jdk:
   - openjdk8
-  - openjdk11
 
 language: scala
 
 scala:
-  - 2.13.4
-  - 2.12.12
+  - 2.13.7
+  - 2.12.15
 
 sudo: required
 
@@ -22,8 +22,8 @@ after_success:
 jobs:
   include:
 
-    - stage: integration-20.x
-      scala: 2.13.4
+    - stage: integration-21.x
+      scala: 2.13.7
       env:
         - AKKA_TEST_TIMEFACTOR=1.5
         - AKKA_TEST_LOGLEVEL=OFF
@@ -39,46 +39,46 @@ jobs:
         - docker run -it --rm -v $HOME/certs:/certs:rw quay.io/ahjohannessen/es-gencert-cli:1.0.1 create-ca -out /certs/ca
         - docker run -it --rm -v $HOME/certs:/certs:rw quay.io/ahjohannessen/es-gencert-cli:1.0.1 create-node -ca-certificate /certs/ca/ca.crt -ca-key /certs/ca/ca.key -out /certs/node -ip-addresses 127.0.0.1
         - sudo chmod -R 777 $HOME/certs
-        - docker pull quay.io/ahjohannessen/esdb:21.2.0
-        - docker run -d --rm --name eventstore-node-20 -p 2114:2113 -p 1114:1113 -v $HOME/certs:/certs -e EVENTSTORE_CERTIFICATE_FILE=/certs/node/node.crt -e EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE=/certs/node/node.key -e EVENTSTORE_TRUSTED_ROOT_CERTIFICATES_PATH=/certs/ca -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True -e EVENTSTORE_RUN_PROJECTIONS=All quay.io/ahjohannessen/esdb:21.2.0
+        - docker pull eventstore/eventstore:21.10.0-bionic
+        - docker run -d --rm --name eventstore-node-20 -p 2114:2113 -p 1114:1113 -v $HOME/certs:/certs -e EVENTSTORE_CERTIFICATE_FILE=/certs/node/node.crt -e EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE=/certs/node/node.key -e EVENTSTORE_TRUSTED_ROOT_CERTIFICATES_PATH=/certs/ca -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True -e EVENTSTORE_RUN_PROJECTIONS=All eventstore/eventstore:21.10.0-bionic
       script:
         - sbt test:compile
         - travis_retry sbt -J-Dconfig.resource=es20-tls.conf it:test
 
     - stage: integration-5.x
-      scala: 2.13.4
+      scala: 2.13.7
       env:
         - AKKA_TEST_TIMEFACTOR=1.5
         - AKKA_TEST_LOGLEVEL=OFF
       before_install:
-        - docker pull eventstore/eventstore:release-5.0.9
-        - docker run -d --rm --name eventstore-node-5 -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=2400 eventstore/eventstore:release-5.0.9
+        - docker pull eventstore/eventstore:release-5.0.11
+        - docker run -d --rm --name eventstore-node-5 -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=2400 eventstore/eventstore:release-5.0.11
       script:
         - sbt test:compile
         - travis_retry sbt it:test
 
-    - stage: integration-cluster-20.x
-      scala: 2.13.4
+    - stage: integration-cluster-21.x
+      scala: 2.13.7
       env: AKKA_TEST_TIMEFACTOR=1.5 AKKA_TEST_LOGLEVEL=OFF
       before_install:
-        - docker pull quay.io/ahjohannessen/esdb:21.2.0
+        - docker pull eventstore/eventstore:21.10.0-bionic
         - docker network create --subnet=172.18.0.0/16 es-net-20
-        - docker run -d --rm --name es1 --net=es-net-20 --ip 172.18.0.2 -p 2114:2113 -p 1114:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.3:2113,172.18.0.4:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True quay.io/ahjohannessen/esdb:21.2.0
-        - docker run -d --rm --name es2 --net=es-net-20 --ip 172.18.0.3 -p 2115:2113 -p 1115:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.2:2113,172.18.0.4:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True quay.io/ahjohannessen/esdb:21.2.0
-        - docker run -d --rm --name es3 --net=es-net-20 --ip 172.18.0.4 -p 2116:2113 -p 1116:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.2:2113,172.18.0.3:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True quay.io/ahjohannessen/esdb:21.2.0
+        - docker run -d --rm --name es1 --net=es-net-20 --ip 172.18.0.2 -p 2114:2113 -p 1114:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.3:2113,172.18.0.4:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True eventstore/eventstore:21.10.0-bionic
+        - docker run -d --rm --name es2 --net=es-net-20 --ip 172.18.0.3 -p 2115:2113 -p 1115:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.2:2113,172.18.0.4:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True eventstore/eventstore:21.10.0-bionic
+        - docker run -d --rm --name es3 --net=es-net-20 --ip 172.18.0.4 -p 2116:2113 -p 1116:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.18.0.2:2113,172.18.0.3:2113 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_INSECURE=True -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_ENABLE_EXTERNAL_TCP=True eventstore/eventstore:21.10.0-bionic
       script:
         - sbt test:compile
         - travis_retry sbt c:test
 
     - stage: integration-cluster-5.x
-      scala: 2.13.4
+      scala: 2.13.7
       env: AKKA_TEST_TIMEFACTOR=1.5 AKKA_TEST_LOGLEVEL=OFF
       before_install:
-        - docker pull eventstore/eventstore:release-5.0.9
+        - docker pull eventstore/eventstore:release-5.0.11
         - docker network create --subnet=172.20.0.0/16 es-net-5
-        - docker run -d --rm --name es1 --net=es-net-5 --ip 172.20.0.2 -p 2114:2113 -p 1114:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.20.0.3:2112,172.20.0.4:2112 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_MEM_DB=True eventstore/eventstore:release-5.0.9
-        - docker run -d --rm --name es2 --net=es-net-5 --ip 172.20.0.3 -p 2115:2113 -p 1115:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.20.0.2:2112,172.20.0.4:2112 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_MEM_DB=True eventstore/eventstore:release-5.0.9
-        - docker run -d --rm --name es3 --net=es-net-5 --ip 172.20.0.4 -p 2116:2113 -p 1116:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.20.0.2:2112,172.20.0.3:2112 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_MEM_DB=True eventstore/eventstore:release-5.0.9
+        - docker run -d --rm --name es1 --net=es-net-5 --ip 172.20.0.2 -p 2114:2113 -p 1114:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.20.0.3:2112,172.20.0.4:2112 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_MEM_DB=True eventstore/eventstore:release-5.0.11
+        - docker run -d --rm --name es2 --net=es-net-5 --ip 172.20.0.3 -p 2115:2113 -p 1115:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.20.0.2:2112,172.20.0.4:2112 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_MEM_DB=True eventstore/eventstore:release-5.0.11
+        - docker run -d --rm --name es3 --net=es-net-5 --ip 172.20.0.4 -p 2116:2113 -p 1116:1113 -e EVENTSTORE_DISCOVER_VIA_DNS=False -e EVENTSTORE_GOSSIP_SEED=172.20.0.2:2112,172.20.0.3:2112 -e EVENTSTORE_CLUSTER_SIZE=3 -e EVENTSTORE_MEM_DB=True eventstore/eventstore:release-5.0.11
       script:
         - sbt test:compile
         - travis_retry sbt c:test

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val commonSettings = Seq(
 
   organization         := "com.geteventstore",
   scalaVersion         := crossScalaVersions.value.head,
-  crossScalaVersions   := Seq("2.13.4", "2.12.13"),
+  crossScalaVersions   := Seq("2.13.7", "2.12.15"),
   releaseCrossBuild    := true,
   licenses             := Seq("BSD 3-Clause" -> url("http://raw.github.com/EventStore/EventStore.JVM/master/LICENSE")),
   homepage             := Some(new URL("http://github.com/EventStore/EventStore.JVM")),

--- a/client/src/main/scala/eventstore/cluster/package.scala
+++ b/client/src/main/scala/eventstore/cluster/package.scala
@@ -12,11 +12,11 @@ package object cluster {
     "Please update your imports, as this deprecated type alias will " +
     "be removed in a future version of EventStore.JVM."
 
-  @deprecated(clusterMsg, sinceV7)
+  @deprecated(clusterMsg, "7.0.0")
   type GossipSeedsOrDns = cc.GossipSeedsOrDns
   val  GossipSeedsOrDns = cc.GossipSeedsOrDns
 
-  @deprecated(clusterMsg, sinceV7)
+  @deprecated(clusterMsg, "7.0.0")
   type ClusterSettings  = cs.ClusterSettings
   val  ClusterSettings  = cs.ClusterSettings
 

--- a/client/src/main/scala/eventstore/package.scala
+++ b/client/src/main/scala/eventstore/package.scala
@@ -3,8 +3,7 @@ package object eventstore {
   import eventstore.{compat, akka => a, core => c}
   import eventstore.core.{settings => cs}
 
-  private[eventstore] final val sinceV7: String = "7.0.0"
-  private[eventstore] def randomUuid: Uuid      = c.util.uuid.randomUuid
+  private[eventstore] def randomUuid: Uuid = c.util.uuid.randomUuid
 
   private final val akkaMsg =
     "This type has been moved from eventstore to eventstore.akka. " +
@@ -15,40 +14,40 @@ package object eventstore {
 
   // TODO(AHJ): Remove akka aliases after 7.1.0
   
-  @deprecated(akkaMsg, sinceV7)
+  @deprecated(akkaMsg, "7.0.0")
   type EsConnection        = a.EsConnection
   val EsConnection         = a.EsConnection
 
-  @deprecated(akkaMsg, sinceV7)
+  @deprecated(akkaMsg, "7.0.0")
   type EventStoreExtension = a.EventStoreExtension
   val EventStoreExtension  = a.EventStoreExtension
 
-  @deprecated(akkaMsg, sinceV7)
+  @deprecated(akkaMsg, "7.0.0")
   type OverflowStrategy    = a.OverflowStrategy
   val OverflowStrategy     = a.OverflowStrategy
 
-  @deprecated(akkaMsg, sinceV7)
+  @deprecated(akkaMsg, "7.0.0")
   type EsTransaction       = a.EsTransaction
   val EsTransaction        = a.EsTransaction
 
-  @deprecated(akkaMsg, sinceV7)
+  @deprecated(akkaMsg, "7.0.0")
   type SubscriptionObserver[T] = a.SubscriptionObserver[T]
 
-  @deprecated(akkaMsg, sinceV7)
+  @deprecated(akkaMsg, "7.0.0")
   type ProjectionsClient   = a.ProjectionsClient
   val ProjectionsClient    = a.ProjectionsClient
 
-  @deprecated(akkaMsg, sinceV7)
+  @deprecated(akkaMsg, "7.0.0")
   val PersistentSubscriptionActor  = a.PersistentSubscriptionActor
 
-  @deprecated(akkaMsg, sinceV7)
+  @deprecated(akkaMsg, "7.0.0")
   val LiveProcessingStarted  = a.LiveProcessingStarted
 
-  @deprecated(akkaMsg, sinceV7)
+  @deprecated(akkaMsg, "7.0.0")
   type Settings              = a.Settings
   val Settings               = a.Settings
 
-  @deprecated(akkaMsg, sinceV7)
+  @deprecated(akkaMsg, "7.0.0")
   type HttpSettings          = a.HttpSettings
   val HttpSettings           = a.HttpSettings
 

--- a/client/src/main/scala/eventstore/tcp/package.scala
+++ b/client/src/main/scala/eventstore/tcp/package.scala
@@ -12,7 +12,7 @@ package object tcp extends TypeAliases {
     "Please update your imports, as this deprecated type alias will " +
     "be removed in a future version of EventStore.JVM."
 
-  @deprecated(tcpMsg, sinceV7)
+  @deprecated(tcpMsg, "7.0.0")
   val ConnectionActor = a.tcp.ConnectionActor
 
 }

--- a/core/src/main/scala/eventstore/core/cluster/NodeState.scala
+++ b/core/src/main/scala/eventstore/core/cluster/NodeState.scala
@@ -14,6 +14,7 @@ object NodeState {
   val values: SortedSet[NodeState] = SortedSet(
     Initializing,
     ReadOnlyLeaderless,
+    DiscoverLeader,
     Unknown,
     PreReadOnlyReplica,
     PreReplica,
@@ -25,7 +26,8 @@ object NodeState {
     Leader,
     Manager,
     ShuttingDown,
-    Shutdown
+    Shutdown,
+    ResigningLeader
   )
 
   final val oldTerminology: Map[String, NodeState] = Map(
@@ -41,7 +43,7 @@ object NodeState {
     map.getOrElse(x, throw new IllegalArgumentException(s"No NodeState found for $x"))
 
   // id value and order derived from:
-  // https://github.com/EventStore/EventStore/blob/2782b20fc3b4c3947fc69a1099840a4815802ae2/src/EventStore.ClientAPI/Messages/ClusterMessages.cs#L66
+  // https://github.com/EventStore/EventStoreDB-Client-Dotnet-Legacy/blob/24cacecb6f003df5015258b05d8356e12c6b694f/src/EventStore.ClientAPI/Messages/ClusterMessages.cs#L74
 
   @SerialVersionUID(1L) case object Initializing extends NodeState {
     def id = 0
@@ -53,63 +55,74 @@ object NodeState {
     def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object Unknown extends NodeState {
+  @SerialVersionUID(1L) case object DiscoverLeader extends NodeState {
     def id = 2
     def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object PreReadOnlyReplica extends NodeState {
+  @SerialVersionUID(1L) case object Unknown extends NodeState {
     def id = 3
     def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object PreReplica extends NodeState {
+  @SerialVersionUID(1L) case object PreReadOnlyReplica extends NodeState {
     def id = 4
     def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object CatchingUp extends NodeState {
+  @SerialVersionUID(1L) case object PreReplica extends NodeState {
     def id = 5
     def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object Clone extends NodeState {
+  @SerialVersionUID(1L) case object CatchingUp extends NodeState {
     def id = 6
     def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object ReadOnlyReplica extends NodeState {
+  @SerialVersionUID(1L) case object Clone extends NodeState {
     def id = 7
     def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object Follower extends NodeState {
+  @SerialVersionUID(1L) case object ReadOnlyReplica extends NodeState {
     def id = 8
     def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object PreLeader extends NodeState {
+  @SerialVersionUID(1L) case object Follower extends NodeState {
     def id = 9
     def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object Leader extends NodeState {
+  @SerialVersionUID(1L) case object PreLeader extends NodeState {
     def id = 10
     def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object Manager extends NodeState {
+  @SerialVersionUID(1L) case object Leader extends NodeState {
     def id = 11
-    def isAllowedToConnect = false
+    def isAllowedToConnect = true
   }
 
-  @SerialVersionUID(1L) case object ShuttingDown extends NodeState {
+  @SerialVersionUID(1L) case object Manager extends NodeState {
     def id = 12
     def isAllowedToConnect = false
   }
 
-  @SerialVersionUID(1L) case object Shutdown extends NodeState {
+  @SerialVersionUID(1L) case object ShuttingDown extends NodeState {
     def id = 13
     def isAllowedToConnect = false
   }
+
+  @SerialVersionUID(1L) case object Shutdown extends NodeState {
+    def id = 14
+    def isAllowedToConnect = false
+  }
+
+   @SerialVersionUID(1L) case object ResigningLeader extends NodeState {
+    def id = 15
+    def isAllowedToConnect = false
+  }
+
 }

--- a/core/src/test/scala/eventstore/core/cluster/NodeStateSpec.scala
+++ b/core/src/test/scala/eventstore/core/cluster/NodeStateSpec.scala
@@ -15,9 +15,9 @@ class NodeStateSpec extends Specification {
 
   "NodeState.isAllowedToConnect" should {
 
-    "return false for Manager, ShuttingDown, Shutdown" in {
+    "return false for Manager, ShuttingDown, Shutdown, ResigningLeader" in {
 
-      val notAllowedStates = Set(Manager, ShuttingDown, Shutdown)
+      val notAllowedStates = Set(Manager, ShuttingDown, Shutdown, ResigningLeader)
       val other = NodeState.values -- notAllowedStates
 
       foreach(notAllowedStates) { state =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,14 +5,14 @@ object Dependencies {
   val protobufVersion = "3.7.1"
   
   val `ts-config`   = "com.typesafe" %  "config"      % "1.4.1"
-  val `scodec-bits` = "org.scodec"   %% "scodec-bits" % "1.1.24"
+  val `scodec-bits` = "org.scodec"   %% "scodec-bits" % "1.1.29"
   val `spray-json`  = "io.spray"     %% "spray-json"  % "1.3.6"
-  val specs2        = "org.specs2"   %% "specs2-core" % "4.10.6"
+  val specs2        = "org.specs2"   %% "specs2-core" % "4.13.0"
 
   ///
 
   object Akka {
-    private val version = "2.6.12"
+    private val version = "2.6.17"
     val actor            = "com.typesafe.akka" %% "akka-actor"          % version
     val stream           = "com.typesafe.akka" %% "akka-stream"         % version
     val testkit          = "com.typesafe.akka" %% "akka-testkit"        % version
@@ -20,7 +20,7 @@ object Dependencies {
   }
 
   object AkkaHttp {
-    private val version = "10.2.3"
+    private val version = "10.2.7"
     val http              = "com.typesafe.akka" %% "akka-http"            % version
     val `http-spray-json` = "com.typesafe.akka" %% "akka-http-spray-json" % version
   }


### PR DESCRIPTION
 - add support for node state `DiscoverLeader` and `ResigningLeader`.

 - adjust tests for soft delete scenarios that
   are not supported in esdb 21.10.0.

 - upgrade various dependencies.

 - adjust travis file for esdb updates

 - fix compiler warning about deprecated usage
   wrt. since not being stable identifier.

 NOTE: all tests have been run locally as travis is no more.