### PR TITLE
TLS support for connections made from cluster discovery funcionality

### DIFF
--- a/client/src/main/scala/eventstore/akka/cluster/ClusterDiscovererActor.scala
+++ b/client/src/main/scala/eventstore/akka/cluster/ClusterDiscovererActor.scala
@@ -177,6 +177,6 @@ private[eventstore] object ClusterDiscovererActor {
   @SerialVersionUID(1L) final case class Address(value: InetSocketAddress)
 
   object Address {
-    def apply(x: MemberInfo): Address = Address(x.externalTcp)
+    def apply(x: MemberInfo): Address = if (x.externalTcp.getPort == 0) Address(x.externalSecureTcp) else Address(x.externalTcp)
   }
 }


### PR DESCRIPTION
When using the cluster gossip seed configuration to connect with an Eventstore that's using TLS, we have something like this in gossip's endpoint response:

> {
      ...
      "internalTcpIp": "eventstore-01.hostname.com",
      "internalTcpPort": 0,
      "internalSecureTcpPort": 1112,
      "externalTcpIp": "eventstore-01.hostname.com",
      "externalTcpPort": 0,
      "externalSecureTcpPort": 1113,
      "httpEndPointIp": "eventstore-01.hostname.com",
      "httpEndPointPort": 2113,
      ...
    }

Note that externalTcpPort is equal 0 in this case.
This PR is just a simple fix that, if not acceptable, would give some path to the real fix.
Please consider this issue, because I noticed that it has already been brought to your attention before.

Kind regards
Miguel